### PR TITLE
feat: prepare YouTubearr v1.20.0 operational polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # YouTubearr Changelog
 
+## [1.20.0] - 2026-06-05
+
+### Added
+
+- **Diagnostics action**: New "Diagnostics" button runs a non-destructive health check and reports plugin state — yt-dlp/QuickJS binary detection, monitoring status, tracked stream counts, EPG source config, webhook config, extraction failure cache state, and any detected issues.
+
+- **Generic media refresh webhook**: Replaces the Jellyfin-specific webhook with a configurable endpoint (`media_refresh_webhook_url`). When new-style settings are used the plugin sends a structured JSON event body; the legacy `webhook_url` field continues to work as a plain bodyless POST (backward-compatible). Optional per-request delay, HTTP method, and header overrides are supported.
+
+- **Generic notification webhook**: Replaces the Telegram-specific notification with a configurable endpoint (`notification_webhook_url`) and base URL (`notification_base_url`). The payload is a generic JSON object suitable for routing to Telegram, Discord, Home Assistant, or any webhook bridge. The legacy `telegram_webhook_url` and `dispatcharr_base_url` fields remain fully supported as aliases.
+
+- **YouTubearr ownership metadata**: Streams and program data created by the plugin are now stamped with `owner: "youtubearr"` in `custom_properties`. This makes plugin-managed records identifiable for future tooling without touching channel or EPG source models.
+
+- **Custom M3U account association**: Streams are now associated with Dispatcharr's built-in custom M3U account at creation time, ensuring compatibility with the current Dispatcharr stream model.
+
+### Fixed
+
+- **Decimal display suffix bug**: Channel display names for decimal sub-channels like `.11`, `.21`, `.31` were showing the wrong suffix (e.g., `#1` instead of `#11`). The suffix is now extracted via string-safe subchannel parsing instead of float math, so channel names correctly show `#11`, `#21`, `#31`, etc.
+
+- **Extraction failure cache is now bounded**: Stale entries older than their TTL are pruned each monitoring cycle. Previously the cache could grow unboundedly over long uptimes.
+
+### Changed
+
+- **Webhook calls are fully non-blocking**: Both media refresh and notification webhooks now fire in short-lived daemon threads. The monitoring loop and manual Refresh action return immediately regardless of webhook delay or remote latency.
+
+### Internal
+
+- Test suite significantly expanded: unit tests now cover webhook resolution, ownership tag stamping, M3U account association, diagnostics, extraction failure pruning, and decimal slot allocation edge cases.
+
 ## [1.19.0] - 2026-05-17
 
 ### Fixed - Title filter now applied before Phase 2 (VirtualRailfan / many-streams fix)

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ YouTubearr is a Dispatcharr plugin that monitors YouTube channels for livestream
 - **Title Filtering**: Regex filters for channels with many simultaneous streams
 - **Quality Selection**: Choose preferred stream quality (Best, 1080p, 720p, 480p)
 - **Channel Profiles**: Automatically add new channels to a Dispatcharr channel profile
-- **Notifications**: Telegram webhook notifications when new streams are added
-- **Jellyfin Integration**: Webhook trigger to refresh Jellyfin guide data automatically
+- **Media Refresh Webhook**: Trigger an external endpoint (e.g., Jellyfin guide refresh) when channels are added or removed
+- **Notification Webhook**: Generic webhook notification when new streams go live — works with Telegram, Discord, Home Assistant, or any webhook bridge
+- **Diagnostics**: Built-in health check action to verify plugin state and configuration
 - **Zero Dependencies**: Bundled yt-dlp binary, no pip installs required
 
 ## Installation
@@ -65,20 +66,98 @@ That's it. No pip install, no apt-get, no API keys. The bundled yt-dlp binary ha
   - **Decimal** (default): Groups streams by YouTube channel (90.1, 90.2, 90.3)
   - **Sequential**: Simple whole numbers (2000, 2001, 2002) for IPTV players that don't handle decimals
 - **Starting Channel Number**: First channel number to assign (default: 2000)
-  - Example: Set to 3000 to start YouTube streams at channel 3000
 - **Channel Number Increment**: How much to increment for each new stream (default: 1)
-  - Example: Set to 10 to assign channels 2000, 2010, 2020, etc.
 - **YouTube Cookies**: Paste cookies in Netscape format for authenticated access
-  - Used as fallback when stream extraction fails
-  - Helps with age-restricted or region-locked content
-  - Export from browser using a cookies extension (e.g., "Get cookies.txt LOCALLY")
 - **Channel Profile**: Optional Dispatcharr channel profile to automatically add new channels to
-- **EPG Source Name**: Name of the EPG source for guide data (default: "YouTube Live")
-- **Webhook URL**: URL to POST when channels are added or removed (e.g., Jellyfin refresh endpoint)
-- **Webhook Delay**: Seconds to wait before triggering the webhook (default: 5)
-- **Telegram Webhook URL**: URL to POST for Telegram notifications when new streams go live
+- **EPG Source Name**: Name of the EPG source for guide data (default: "YouTube Live"). Supports `{title}` and `{channel}` placeholders.
 - **Manual URL**: Paste a YouTube livestream URL for quick manual addition
-- **Dispatcharr Base URL**: Base URL for stream links in notifications (e.g., https://tv.example.com)
+
+### Webhook Settings
+
+#### Media Refresh Webhook
+
+Triggers an external endpoint whenever channels are added or removed. Use this to automatically refresh Jellyfin, Emby, Plex, or any guide consumer.
+
+| Setting | Description |
+|---------|-------------|
+| `media_refresh_webhook_url` | URL to POST when channels change. Leave empty to disable. |
+| `media_refresh_webhook_delay_seconds` | Delay before sending (default: 5s). Allows Dispatcharr to finish processing first. |
+| `media_refresh_webhook_headers` | Optional JSON object of extra request headers (e.g., `{"Authorization": "Bearer TOKEN"}`). |
+| `media_refresh_webhook_body_template` | Optional static JSON body to send. Leave empty to use the default event payload. |
+
+**Legacy alias**: The old `webhook_url` field continues to work as a plain bodyless POST (Jellyfin-style). Set `media_refresh_webhook_url` to migrate to the generic form.
+
+#### Notification Webhook
+
+Sends a JSON event notification when a new stream is added. Works with any HTTP endpoint — Telegram bot bridges, Discord webhooks, Home Assistant, n8n, etc.
+
+| Setting | Description |
+|---------|-------------|
+| `notification_webhook_url` | URL to POST new-stream notifications. Leave empty to disable. |
+| `notification_base_url` | Base URL for Dispatcharr stream links in the payload (e.g., `https://tv.example.com`). |
+| `notification_webhook_headers` | Optional JSON object of extra request headers. |
+
+**Legacy aliases**: The old `telegram_webhook_url` and `dispatcharr_base_url` fields continue to work unchanged. Set `notification_webhook_url` / `notification_base_url` to migrate.
+
+## Notifications and Webhooks
+
+YouTubearr supports two independent webhook types that serve different purposes.
+
+### Media Refresh Webhook
+
+Fires after channels are added or removed. Intended to tell your media server to refresh its guide.
+
+**Default event payload** (when `media_refresh_webhook_url` is set without a body template):
+```json
+{
+  "event": "media_refresh_requested",
+  "plugin": "youtubearr",
+  "reason": "streams_changed",
+  "timestamp": "2026-06-05T12:00:00+00:00"
+}
+```
+
+**Jellyfin example** (bodyless POST — use the legacy `webhook_url` field or a body template):
+```
+http://jellyfin:8096/ScheduledTasks/Running/TASK_ID?api_key=YOUR_API_KEY
+```
+
+### Notification Webhook
+
+Fires when a new stream is added (monitoring or manual). Delivers stream metadata to whatever endpoint you configure.
+
+**Event payload** (`notification_webhook_url`):
+```json
+{
+  "event": "stream_added",
+  "plugin": "youtubearr",
+  "video_id": "abc123defgh",
+  "title": "🔴 LIVE - Stream Title",
+  "channel_name": "YouTube Channel Name",
+  "channel_number": "90.1",
+  "dispatcharr_channel_uuid": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "url": "https://tv.example.com/proxy/ts/stream/UUID",
+  "thumbnail": "https://i.ytimg.com/vi/abc123defgh/hqdefault_live.jpg",
+  "timestamp": "2026-06-05T12:00:00+00:00"
+}
+```
+
+**Legacy payload** (`telegram_webhook_url`): The old Telegram-specific field preserves the original key shape for compatibility:
+```json
+{
+  "title": "🔴 LIVE - Stream Title",
+  "channel": "YouTube Channel Name",
+  "url": "https://tv.example.com/proxy/ts/stream/UUID",
+  "description": "Added as Dispatcharr Channel #90.1",
+  "timestamp": "2026-06-05T12:00:00+00:00"
+}
+```
+
+Route the generic payload to a Telegram bot bridge, Discord webhook, Home Assistant webhook automation, or any HTTP-capable service.
+
+### Best-effort delivery
+
+Both webhooks are **best-effort**: failures are logged to `youtubearr.log` but do not block stream creation, monitoring, or the Refresh action. Webhook calls run in background threads, so configured delays never stall the caller.
 
 ## EPG Setup
 
@@ -100,26 +179,15 @@ Then set the same name in YouTubearr's **EPG Source Name** setting.
 
 **Note:** The Dummy EPG source acts as a container for YouTubearr's programme data. The plugin creates `ProgramData` entries directly with the livestream title, bypassing the Dummy EPG's pattern-based generation.
 
-### Step 2: Refresh the Guide in Jellyfin
+### Step 2: Refresh the Guide
 
-After YouTubearr adds new channels, Jellyfin needs to refresh its guide data to display them.
-
-#### Manual Refresh
-
-1. Open Jellyfin and go to **Dashboard → Scheduled Tasks**
-2. Find **Refresh Guide** in the task list
-3. Click the **Play** button to run it immediately
+After YouTubearr adds new channels, your media server needs to refresh its guide data.
 
 #### Automatic Refresh (Recommended)
 
-Set up a scheduled refresh so new YouTube channels appear automatically:
+Set the **Media Refresh Webhook URL** in YouTubearr settings to your media server's refresh endpoint. The plugin will trigger it automatically whenever channels change.
 
-1. Go to **Dashboard → Scheduled Tasks → Refresh Guide**
-2. Click on the task to edit its schedule
-3. Set it to run every few hours (e.g., every 4 hours) or at specific times
-4. Click **Save**
-
-**Tip:** YouTubearr can trigger a Jellyfin webhook when channels are added. Set the **Webhook URL** in YouTubearr settings to:
+**Jellyfin example:**
 ```
 http://jellyfin:8096/ScheduledTasks/Running/TASK_ID?api_key=YOUR_API_KEY
 ```
@@ -129,6 +197,12 @@ To find your Refresh Guide task ID:
 curl "http://jellyfin:8096/ScheduledTasks?api_key=YOUR_API_KEY" | grep -A2 "RefreshGuide"
 ```
 
+#### Manual Refresh
+
+1. Open Jellyfin and go to **Dashboard → Scheduled Tasks**
+2. Find **Refresh Guide** in the task list
+3. Click the **Play** button to run it immediately
+
 ## Usage
 
 ### Adding a Stream Manually
@@ -136,7 +210,7 @@ curl "http://jellyfin:8096/ScheduledTasks?api_key=YOUR_API_KEY" | grep -A2 "Refr
 1. Copy a YouTube livestream URL (e.g., `https://www.youtube.com/watch?v=VIDEO_ID`)
 2. Open YouTubearr plugin settings in Dispatcharr
 3. Paste the URL into the **Manual YouTube URL** field
-4. Click the **Add Stream** button
+4. Click the **Add Streams** button
 5. The stream will appear as a new channel in your Dispatcharr feed
 
 ### Monitoring YouTube Channels
@@ -152,12 +226,13 @@ curl "http://jellyfin:8096/ScheduledTasks?api_key=YOUR_API_KEY" | grep -A2 "Refr
 
 ### Manual Actions
 
-- **Add Stream**: Add a single stream from the Manual URL field
+- **Add Streams**: Add one or more streams from the Manual URL field
 - **Start Monitoring**: Begin automatic monitoring of configured channels
 - **Stop Monitoring**: Stop automatic monitoring
 - **Refresh Now**: Immediately check for new/ended livestreams (bypasses poll interval)
 - **Cleanup**: Manually remove all channels for ended streams
 - **Reset All**: Remove all YouTubearr channels and clear all plugin state
+- **Diagnostics**: Run a non-destructive health check — reports binary detection, monitoring status, webhook configuration, EPG state, and any detected issues
 
 ## Channel Numbering
 
@@ -255,6 +330,7 @@ Some YouTube channels (like VirtualRailfan) have 70+ simultaneous streams. Use t
 - Verify the YouTube stream is actually live (not a premiere or scheduled stream)
 - Check the youtubearr.log file for error messages
 - Try adding the stream manually first to verify yt-dlp is working
+- Run the **Diagnostics** action to check binary detection and plugin state
 
 ### Stream playback issues
 
@@ -267,6 +343,12 @@ Some YouTube channels (like VirtualRailfan) have 70+ simultaneous streams. Use t
 - Use the **Cleanup** action to remove channels for ended streams
 - This can happen if monitoring was stopped while streams were active
 
+### Webhook not firing
+
+- Run **Diagnostics** — it reports whether each webhook is configured and flags malformed header JSON
+- Check `youtubearr.log` for `[media_refresh]` or `[notification]` entries
+- Both webhooks are best-effort; failures are logged and do not block stream creation
+
 ## Technical Details
 
 - **yt-dlp**: Used for all YouTube interactions (stream detection, URL extraction, metadata)
@@ -277,6 +359,11 @@ Some YouTube channels (like VirtualRailfan) have 70+ simultaneous streams. Use t
 - **Cookies Fallback**: Optional cookie authentication with automatic retry on extraction failure
 - **Thread Safety**: Uses Django's select_for_update() to prevent race conditions
 - **Auto-Recovery**: Monitoring automatically resumes after container/service restarts
+- **Ownership Tags**: Streams and program data are stamped with `owner: "youtubearr"` in custom properties
+
+## Scope
+
+YouTubearr is focused on YouTube livestreams. Twitch support is intentionally out of scope for this plugin — it belongs in a dedicated project (Twitcharr) to keep each plugin simple and purpose-built.
 
 ## Logs
 
@@ -289,7 +376,7 @@ tail -f /app/data/plugins/youtubearr/youtubearr.log
 
 ## Support
 
-- GitHub Issues: https://github.com/jeff-gooch/Youtubearr/issues
+- GitHub Issues: https://github.com/jeff-gooch/youtubearr/issues
 - Dispatcharr Discord: https://discord.gg/dispatcharr
 
 ## License

--- a/deploy.sh
+++ b/deploy.sh
@@ -38,17 +38,29 @@ esac
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
+# Portable python runner: tries python3, then python, then nix-shell fallback.
+run_python() {
+  if command -v python3 &>/dev/null; then
+    python3 "$@"
+  elif command -v python &>/dev/null; then
+    python "$@"
+  elif command -v nix-shell &>/dev/null; then
+    nix-shell -p python3 --run "python3 $*"
+  else
+    echo "ERROR: No Python interpreter found (tried python3, python, nix-shell)" >&2
+    exit 1
+  fi
+}
+
 run_tests() {
   echo "Running unit tests..."
   cd "$SCRIPT_DIR"
-  nix-shell -p python3 --run "python3 -m unittest discover tests/ -v -p 'test_plugin.py'" 2>/dev/null \
-    || python -m unittest discover tests/ -v -p "test_plugin.py"
+  run_python -m unittest discover tests/ -v -p "test_plugin.py"
   echo "Unit tests passed."
 
   if $RUN_INTEGRATION; then
     echo "Running integration tests (requires internet + real yt-dlp, ~60s)..."
-    nix-shell -p python3 --run "python3 -m unittest tests/test_integration.py -v" 2>/dev/null \
-      || python -m unittest tests/test_integration.py -v
+    run_python -m unittest tests/test_integration.py -v
     echo "Integration tests passed."
   fi
 }
@@ -95,15 +107,29 @@ case "$TARGET" in
     ;;
 
   publish)
-    VERSION=$(nix-shell -p python3 --run "python3 -c \"import json; print(json.load(open('$SCRIPT_DIR/plugin.json'))['version'])\"" 2>/dev/null \
-              || python -c "import json; print(json.load(open('$SCRIPT_DIR/plugin.json'))['version'])")
-    PLUGINS_DIR="/home/gooch/dispatcharr-plugins"
+    VERSION=$(run_python -c "import json; print(json.load(open('$SCRIPT_DIR/plugin.json'))['version'])")
+    PLUGINS_DIR="${DISPATCHARR_PLUGINS_DIR:-$HOME/dispatcharr-plugins}"
     BRANCH="youtubearr/v${VERSION}"
 
     echo "Publishing v${VERSION} to dispatcharr/Plugins..."
 
-    cd "$PLUGINS_DIR"
-    git fetch upstream
+    # Clone plugins directory if missing
+    if [ ! -d "$PLUGINS_DIR" ]; then
+      echo "Plugins directory not found at $PLUGINS_DIR — attempting clone..."
+      if command -v git &>/dev/null; then
+        git clone https://github.com/jeff-gooch/Plugins.git "$PLUGINS_DIR"
+        cd "$PLUGINS_DIR"
+        git remote add upstream https://github.com/Dispatcharr/Plugins.git
+        git fetch upstream
+      else
+        echo "ERROR: $PLUGINS_DIR does not exist and git is not available to clone it."
+        exit 1
+      fi
+    else
+      cd "$PLUGINS_DIR"
+      git fetch upstream
+    fi
+
     git checkout main
     git merge upstream/main --ff-only
     git push origin main
@@ -124,13 +150,27 @@ case "$TARGET" in
     git push origin "$BRANCH"
 
     echo "Creating PR on dispatcharr/Plugins..."
-    nix-shell -p gh --run "gh pr create \
-      --repo Dispatcharr/Plugins \
-      --head jeff-gooch:${BRANCH} \
-      --base main \
-      --title '[youtubearr] Bump version to ${VERSION}' \
-      --body 'Bumps YouTubearr to v${VERSION}. See https://github.com/jeff-gooch/youtubearr/releases/tag/v${VERSION} for changelog.'" \
-    || echo "PR may already exist — check https://github.com/Dispatcharr/Plugins/pulls"
+    # Prefer gh on PATH over nix-shell fallback
+    if command -v gh &>/dev/null; then
+      gh pr create \
+        --repo Dispatcharr/Plugins \
+        --head jeff-gooch:${BRANCH} \
+        --base main \
+        --title "[youtubearr] Bump version to ${VERSION}" \
+        --body "Bumps YouTubearr to v${VERSION}. See https://github.com/jeff-gooch/youtubearr/releases/tag/v${VERSION} for changelog." \
+      || echo "PR may already exist — check https://github.com/Dispatcharr/Plugins/pulls"
+    elif command -v nix-shell &>/dev/null; then
+      nix-shell -p gh --run "gh pr create \
+        --repo Dispatcharr/Plugins \
+        --head jeff-gooch:${BRANCH} \
+        --base main \
+        --title '[youtubearr] Bump version to ${VERSION}' \
+        --body 'Bumps YouTubearr to v${VERSION}. See https://github.com/jeff-gooch/youtubearr/releases/tag/v${VERSION} for changelog.'" \
+      || echo "PR may already exist — check https://github.com/Dispatcharr/Plugins/pulls"
+    else
+      echo "ERROR: gh CLI not available — cannot create PR."
+      exit 1
+    fi
     ;;
 
   setup-test)

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "YouTubearr",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Zero-dependency YouTube livestream plugin with automatic monitoring and configurable numbering",
   "author": "jeff-gooch",
   "license": "Unlicense",

--- a/plugin.py
+++ b/plugin.py
@@ -24,7 +24,7 @@ from core.scheduling import create_or_update_periodic_task, delete_periodic_task
 
 class Plugin:
     name = "YouTubearr"
-    version = "1.19.0"
+    version = "1.20.0"
     description = "Zero-dependency YouTube livestream plugin with automatic monitoring and configurable numbering"
     author = "Jeff Gooch"
     help_url = "https://github.com/jeff-gooch/youtubearr"
@@ -154,39 +154,102 @@ class Plugin:
         },
         {
             "id": "info_webhook",
-            "label": "Webhook Integration",
+            "label": "Webhooks",
             "type": "info",
-            "description": "Trigger external services (like Jellyfin LiveTV refresh) when channels are added or removed.",
+            "description": "Trigger external services when channels are added or removed, and send notifications for new streams.",
         },
         {
-            "id": "webhook_url",
-            "label": "Webhook URL (Jellyfin)",
+            "id": "info_generic_webhooks",
+            "label": "Generic Webhooks",
+            "type": "info",
+            "description": "Configure generic webhook endpoints for media refresh and stream notifications.",
+        },
+        {
+            "id": "media_refresh_webhook_url",
+            "label": "Media Refresh Webhook URL",
             "type": "string",
             "default": "",
-            "help_text": "URL to POST when channels change (e.g., Jellyfin refresh). Leave empty to disable.",
+            "help_text": "URL to POST when channels are added or removed (e.g., Jellyfin, Emby, Plex guide refresh). Sends a structured JSON event body. Leave empty to disable.",
         },
         {
-            "id": "webhook_delay_seconds",
-            "label": "Webhook Delay (seconds)",
+            "id": "media_refresh_webhook_delay_seconds",
+            "label": "Media Refresh Webhook Delay (seconds)",
             "type": "number",
             "default": 5,
             "min": 0,
             "max": 60,
-            "help_text": "Delay before triggering webhook to allow Dispatcharr to finish processing (default: 5 seconds).",
+            "help_text": "Delay before sending the media refresh webhook to allow Dispatcharr to finish processing (default: 5 seconds).",
+        },
+        {
+            "id": "media_refresh_webhook_headers",
+            "label": "Media Refresh Webhook Headers",
+            "type": "string",
+            "default": "",
+            "help_text": "Optional JSON object of extra request headers (e.g., {\"Authorization\": \"Bearer TOKEN\"}). Leave empty for no extra headers.",
+        },
+        {
+            "id": "media_refresh_webhook_body_template",
+            "label": "Media Refresh Webhook Body Template",
+            "type": "text",
+            "default": "",
+            "help_text": "Optional static JSON or text body to send. Leave empty to use the default event payload.",
+        },
+        {
+            "id": "notification_webhook_url",
+            "label": "Notification Webhook URL",
+            "type": "string",
+            "default": "",
+            "help_text": "URL to POST when a new stream is added. Sends a generic JSON payload suitable for Telegram bots, Discord, Home Assistant, n8n, or any webhook bridge. Leave empty to disable.",
+        },
+        {
+            "id": "notification_base_url",
+            "label": "Notification Base URL",
+            "type": "string",
+            "default": "",
+            "help_text": "Base URL for Dispatcharr stream links in the notification payload (e.g., https://tv.example.com). Used to build stream URLs like {base_url}/proxy/ts/stream/{uuid}.",
+        },
+        {
+            "id": "notification_webhook_headers",
+            "label": "Notification Webhook Headers",
+            "type": "string",
+            "default": "",
+            "help_text": "Optional JSON object of extra request headers. Leave empty for no extra headers.",
+        },
+        {
+            "id": "info_legacy_webhooks",
+            "label": "Legacy Webhook Aliases",
+            "type": "info",
+            "description": "These fields are kept for backward compatibility. Prefer the generic webhook fields above for new setups.",
+        },
+        {
+            "id": "webhook_url",
+            "label": "Webhook URL (Legacy — media refresh alias, bodyless POST)",
+            "type": "string",
+            "default": "",
+            "help_text": "Legacy media refresh alias. Sends a bodyless POST (original Jellyfin-style). Use 'Media Refresh Webhook URL' above for new setups.",
+        },
+        {
+            "id": "webhook_delay_seconds",
+            "label": "Webhook Delay (Legacy — media refresh delay alias)",
+            "type": "number",
+            "default": 5,
+            "min": 0,
+            "max": 60,
+            "help_text": "Legacy media refresh delay alias. Use 'Media Refresh Webhook Delay' above for new setups.",
         },
         {
             "id": "telegram_webhook_url",
-            "label": "Telegram Notification URL",
+            "label": "Telegram Notification URL (Legacy — notification alias)",
             "type": "string",
             "default": "",
-            "help_text": "URL to POST for Telegram notifications when new channels are added (e.g., https://example.com/webhook/notify). Leave empty to disable.",
+            "help_text": "Legacy notification alias. Preserves the original Telegram payload shape for compatibility. Use 'Notification Webhook URL' above for new setups.",
         },
         {
             "id": "dispatcharr_base_url",
-            "label": "Dispatcharr Base URL",
+            "label": "Dispatcharr Base URL (Legacy — notification base URL alias)",
             "type": "string",
             "default": "",
-            "help_text": "Base URL for Dispatcharr stream links in notifications (e.g., https://tv.example.com). Used to build stream URLs like {base_url}/proxy/ts/stream/{uuid}.",
+            "help_text": "Legacy notification base URL alias. Use 'Notification Base URL' above for new setups.",
         },
         {
             "id": "info_epg",
@@ -274,6 +337,13 @@ class Plugin:
             "button_label": "Reset All",
             "button_color": "red",
         },
+        {
+            "id": "diagnostics",
+            "label": "Diagnostics",
+            "description": "Run a non-destructive YouTubearr health check",
+            "button_label": "Diagnostics",
+            "button_color": "blue",
+        },
     ]
 
     def __init__(self) -> None:
@@ -333,6 +403,8 @@ class Plugin:
             response = self._handle_cleanup(context)
         elif action == "reset_all":
             response = self._handle_reset_all(context)
+        elif action == "diagnostics":
+            response = self._handle_diagnostics(context)
         else:
             response = {"status": "error", "message": f"Unknown action '{action}'"}
 
@@ -869,6 +941,218 @@ class Plugin:
             self._log_error(f"Reset All failed: {exc}")
             return {"status": "error", "message": f"Reset failed: {str(exc)}"}
 
+    # --- Diagnostics ---
+
+    def _handle_diagnostics(self, context: Dict[str, Any]) -> Dict[str, Any]:
+        """Run a non-destructive health check and return diagnostics details."""
+        settings = context.get("settings", {})
+        issues: List[str] = []  # "error:<reason>" or "warning:<reason>"
+        details: Dict[str, Any] = {}
+
+        # Plugin identity
+        details["plugin_version"] = self.version
+        details["plugin_key"] = self._plugin_key
+
+        # Monitoring state
+        monitoring_active_db = settings.get("monitoring_active", False)
+        details["monitoring_active"] = monitoring_active_db
+        thread_alive = bool(self._monitor_thread and self._monitor_thread.is_alive())
+        details["monitor_thread_alive"] = thread_alive
+        details["last_poll_time"] = settings.get("last_poll_time") or "unknown"
+        details["monitoring_heartbeat"] = settings.get("monitoring_heartbeat") or "unknown"
+
+        if monitoring_active_db and not thread_alive:
+            heartbeat_str = settings.get("monitoring_heartbeat")
+            if heartbeat_str:
+                try:
+                    hb = datetime.fromisoformat(heartbeat_str.replace("Z", "+00:00"))
+                    if hb.tzinfo is None:
+                        hb = hb.replace(tzinfo=dt_timezone.utc)
+                    if (datetime.now(tz=dt_timezone.utc) - hb).total_seconds() > 600:
+                        issues.append("warning:monitoring active but heartbeat is stale (>10 min)")
+                except Exception:
+                    issues.append("warning:monitoring active but heartbeat is unparseable")
+            else:
+                issues.append("warning:monitoring active but no heartbeat found")
+
+        # Monitored channels / tracked streams
+        monitored_raw = settings.get("monitored_channels", "").strip()
+        details["monitored_channel_count"] = (
+            len([l for l in monitored_raw.splitlines() if l.strip()]) if monitored_raw else 0
+        )
+        tracked_streams = settings.get("tracked_streams", {})
+        details["tracked_stream_count"] = len(tracked_streams)
+
+        # Extraction failures
+        failure_count = len(self._extraction_failures)
+        details["extraction_failure_count"] = failure_count
+        if failure_count > 0:
+            try:
+                ts_list = [float(t) for t in self._extraction_failures.values()]
+                details["extraction_failure_oldest"] = datetime.fromtimestamp(
+                    min(ts_list), tz=dt_timezone.utc
+                ).isoformat()
+                details["extraction_failure_newest"] = datetime.fromtimestamp(
+                    max(ts_list), tz=dt_timezone.utc
+                ).isoformat()
+            except Exception:
+                details["extraction_failure_oldest"] = "unavailable"
+                details["extraction_failure_newest"] = "unavailable"
+
+        # yt-dlp binary
+        details["ytdlp_path"] = self._ytdlp_path or "not found"
+        details["ytdlp_version"] = self._get_ytdlp_version()
+        if not self._ytdlp_path:
+            issues.append("error:yt-dlp binary not found")
+
+        # QuickJS binary
+        details["qjs_path"] = self._qjs_path or "not found"
+        details["qjs_version"] = self._get_qjs_version()
+
+        # Cookies (configured/present, never expose content)
+        cookies_raw = settings.get("cookies_content", "")
+        details["cookies_configured"] = bool(cookies_raw and cookies_raw.strip())
+        details["cookies_file_present"] = (self._base_dir / "cookies.txt").exists()
+
+        # Webhooks
+        media_cfg = self._get_media_refresh_webhook_config(settings)
+        details["media_refresh_webhook_configured"] = bool(media_cfg.get("url"))
+        details["media_refresh_webhook_is_legacy"] = media_cfg.get("is_legacy", False)
+        if settings.get("media_refresh_webhook_headers", "").strip() and not media_cfg.get("headers"):
+            issues.append("warning:media refresh webhook headers are invalid JSON")
+
+        notif_cfg = self._get_notification_webhook_config(settings)
+        details["notification_webhook_configured"] = bool(notif_cfg.get("url"))
+        details["notification_webhook_is_legacy"] = notif_cfg.get("is_legacy", False)
+        if settings.get("notification_webhook_headers", "").strip() and not notif_cfg.get("headers"):
+            issues.append("warning:notification webhook headers are invalid JSON")
+
+        # DB counts (best effort — defensive against mocked/unavailable Django)
+        details["owned_streams"] = self._count_owned_streams()
+        details["owned_channels"] = self._count_owned_channels()
+        details["owned_programs"] = self._count_owned_programs()
+        for key in ("owned_streams", "owned_channels", "owned_programs"):
+            if isinstance(details.get(key), str) and "unavailable" in details[key]:
+                issues.append(f"warning:{key} count unavailable")
+        details["epg_counts"] = self._get_epg_counts(settings)
+
+        # Recent log summary
+        details["log_summary"] = self._get_recent_log_summary()
+
+        # Status
+        errors = [i for i in issues if i.startswith("error:")]
+        warnings = [i for i in issues if i.startswith("warning:")]
+        if errors:
+            status, message = "error", "YouTubearr diagnostics found errors"
+        elif warnings:
+            status, message = "warning", "YouTubearr diagnostics completed with warnings"
+        else:
+            status, message = "success", "YouTubearr diagnostics completed: healthy"
+
+        return {"status": status, "message": message, "details": details}
+
+    def _get_ytdlp_version(self) -> str:
+        """Return yt-dlp version string, or a safe error description."""
+        if not self._ytdlp_path:
+            return "unavailable: yt-dlp not found"
+        try:
+            result = subprocess.run(
+                [self._ytdlp_path, "--version"],
+                capture_output=True, text=True, timeout=5,
+            )
+            ver = result.stdout.strip() or result.stderr.strip()
+            return ver if ver else "unknown"
+        except FileNotFoundError:
+            return "unavailable: binary not found"
+        except subprocess.TimeoutExpired:
+            return "unavailable: timeout"
+        except Exception as exc:
+            return f"unavailable: {exc}"
+
+    def _get_qjs_version(self) -> str:
+        """Return QuickJS version string from --version output (may exit nonzero)."""
+        if not self._qjs_path:
+            return "not configured"
+        try:
+            result = subprocess.run(
+                [self._qjs_path, "--version"],
+                capture_output=True, text=True, timeout=5,
+            )
+            combined = (result.stdout + result.stderr).strip()
+            m = re.search(r"QuickJS(?:-ng)?\s+version\s+\S+", combined, re.IGNORECASE)
+            if m:
+                return m.group(0)
+            return combined[:80] if combined else "unknown"
+        except FileNotFoundError:
+            return "unavailable: binary not found"
+        except subprocess.TimeoutExpired:
+            return "unavailable: timeout"
+        except Exception as exc:
+            return f"unavailable: {exc}"
+
+    def _count_owned_streams(self) -> Any:
+        try:
+            return Stream.objects.filter(custom_properties__owner="youtubearr").count()
+        except Exception as exc:
+            return f"unavailable: {type(exc).__name__}"
+
+    def _count_owned_channels(self) -> Any:
+        try:
+            return Channel.objects.filter(
+                streams__custom_properties__owner="youtubearr"
+            ).distinct().count()
+        except Exception as exc:
+            return f"unavailable: {type(exc).__name__}"
+
+    def _count_owned_programs(self) -> Any:
+        try:
+            return ProgramData.objects.filter(custom_properties__owner="youtubearr").count()
+        except Exception as exc:
+            return f"unavailable: {type(exc).__name__}"
+
+    def _get_epg_counts(self, settings: Dict[str, Any]) -> Dict[str, Any]:
+        epg_source_name = settings.get("epg_source_name", "YouTube Live").strip()
+        result: Dict[str, Any] = {}
+        try:
+            source = EPGSource.objects.filter(name=epg_source_name).first()
+            if source:
+                result["epg_source"] = epg_source_name
+                result["epg_data_count"] = EPGData.objects.filter(epg_source=source).count()
+                result["program_count"] = ProgramData.objects.filter(epg__epg_source=source).count()
+            else:
+                result["epg_source"] = f"{epg_source_name} (not found)"
+                result["epg_data_count"] = 0
+                result["program_count"] = 0
+        except Exception as exc:
+            result["epg_source"] = f"unavailable: {type(exc).__name__}"
+            result["epg_data_count"] = f"unavailable: {type(exc).__name__}"
+            result["program_count"] = f"unavailable: {type(exc).__name__}"
+        return result
+
+    def _get_recent_log_summary(self) -> Dict[str, Any]:
+        result: Dict[str, Any] = {"error_count": 0, "recent_errors": [], "status": "ok"}
+        if not self._log_path.exists():
+            result["status"] = "log file not found"
+            return result
+        try:
+            max_bytes = 32 * 1024
+            size = self._log_path.stat().st_size
+            with open(self._log_path, "rb") as f:
+                if size > max_bytes:
+                    f.seek(size - max_bytes)
+                raw = f.read(max_bytes)
+            text = raw.decode("utf-8", errors="replace")
+            lines = text.splitlines()
+            if size > max_bytes and lines:
+                lines = lines[1:]  # drop possibly-truncated first line
+            error_lines = [l for l in lines if "ERROR:" in l]
+            result["error_count"] = len(error_lines)
+            result["recent_errors"] = [e[-120:] for e in error_lines[-5:]]
+            result["lines_scanned"] = len(lines)
+        except Exception as exc:
+            result["status"] = f"read failed: {type(exc).__name__}"
+        return result
+
     # --- YouTube URL Parsing ---
 
     def _extract_video_id(self, url: str) -> Optional[str]:
@@ -1096,6 +1380,7 @@ class Plugin:
         cfg = PluginConfig.objects.select_for_update().get(key=self._plugin_key)
 
         video_title = metadata.get("title", "YouTube Live")
+        video_id = metadata.get("video_id", "")
         stream_url = metadata.get("stream_url", "")
         thumbnail = metadata.get("thumbnail", "")
         channel_thumbnail = metadata.get("channel_thumbnail", "")
@@ -1111,6 +1396,29 @@ class Plugin:
             stream_profile_id=self._get_stream_profile_id(settings),
         )
 
+        # Apply YouTubearr ownership tags to stream custom_properties
+        try:
+            _existing = getattr(stream, 'custom_properties', None)
+            stream.custom_properties = self._merge_youtubearr_custom_properties(
+                _existing if isinstance(_existing, dict) else {},
+                youtube_video_id=video_id,
+                youtube_channel_id=youtube_channel_id,
+                stream_url_refreshed_at=timezone.now().isoformat(),
+            )
+            stream.save(update_fields=['custom_properties'])
+        except Exception:
+            pass  # custom_properties field may not exist on this Dispatcharr version
+
+        # Associate stream with custom M3U account for correct playback routing
+        try:
+            m3u_account = self._get_custom_m3u_account()
+            if m3u_account is not None:
+                stream.is_custom = True
+                stream.m3u_account = m3u_account
+                stream.save(update_fields=['is_custom', 'm3u_account'])
+        except Exception:
+            pass  # Fields may not exist on this Dispatcharr version
+
         # Get or create channel group
         group_name = settings.get("channel_group_name", self._channel_group_name)
         group, _ = ChannelGroup.objects.get_or_create(name=group_name)
@@ -1124,14 +1432,9 @@ class Plugin:
         # Format channel name as: {youtube_channel_name} #{stream_number}
         numbering_mode = settings.get("channel_numbering_mode", "decimal")
         if numbering_mode == "decimal":
-            # Extract stream number from sub-channel (e.g., 93.2 → #2)
-            decimal_part = channel_number % 1
-            if decimal_part > 0:
-                stream_number = int(round(decimal_part * 10))
-                if stream_number == 0:
-                    stream_number = int(round(decimal_part * 100))  # Handle .01, .02, etc.
-            else:
-                stream_number = 1
+            # Extract stream number using string-safe parsing (e.g., 93.2 → 2, 93.11 → 11).
+            # Float math (decimal_part * 10) gives wrong results for values >= .10.
+            stream_number = self._get_subchannel_index(channel_number)
         else:
             # Sequential mode: count ACTIVE streams from this YouTube channel + 1.
             # Only count tracked_streams entries whose channel_id still exists in the DB.
@@ -1222,7 +1525,7 @@ class Plugin:
 
                 # Ensure a single program exists so the guide shows the stream title.
                 now = timezone.now()
-                ProgramData.objects.update_or_create(
+                program_obj, _ = ProgramData.objects.update_or_create(
                     epg=epg_data,
                     tvg_id=channel_tvg_id,
                     defaults={
@@ -1232,6 +1535,16 @@ class Plugin:
                         "end_time": now + timedelta(hours=12),
                     },
                 )
+                try:
+                    _existing_pp = getattr(program_obj, 'custom_properties', None)
+                    program_obj.custom_properties = self._merge_youtubearr_custom_properties(
+                        _existing_pp if isinstance(_existing_pp, dict) else {},
+                        youtube_video_id=video_id,
+                        youtube_channel_id=youtube_channel_id,
+                    )
+                    program_obj.save(update_fields=['custom_properties'])
+                except Exception:
+                    pass  # custom_properties may not exist on this Dispatcharr version
             except Exception as epg_exc:
                 self._log(f"Could not assign EPG: {epg_exc}")
 
@@ -2449,6 +2762,14 @@ class Plugin:
                     # This prevents other Celery workers from starting duplicate threads
                     self._persist_settings({"monitoring_heartbeat": timezone.now().isoformat()})
 
+                    # Prune stale extraction failures to keep the dict bounded
+                    try:
+                        _pruned = self._prune_extraction_failures()
+                        if _pruned:
+                            self._log(f"Pruned {_pruned} stale extraction failure(s)")
+                    except Exception:
+                        pass
+
                     # Poll channels
                     try:
                         added, ended = self._poll_monitored_channels(settings)
@@ -2518,6 +2839,100 @@ class Plugin:
                 cfg.save(update_fields=["settings", "updated_at"])
         except PluginConfig.DoesNotExist:
             self._log_error("Plugin config not found")
+
+    # --- Operational Helpers ---
+
+    def _prune_extraction_failures(self, ttl_days: int = 7, now: Optional[float] = None) -> int:
+        """Remove extraction failure entries older than ttl_days from the in-memory dict.
+
+        Returns count of pruned entries. Malformed timestamps are also pruned.
+        Future timestamps (members-only entries stored at now+6days) are preserved.
+        """
+        if now is None:
+            now = time.time()
+        cutoff = now - ttl_days * 86400
+        to_prune = []
+        for vid, fail_time in list(self._extraction_failures.items()):
+            try:
+                if float(fail_time) < cutoff:
+                    to_prune.append(vid)
+            except (TypeError, ValueError):
+                to_prune.append(vid)  # Malformed timestamp — prune it
+        for vid in to_prune:
+            del self._extraction_failures[vid]
+        return len(to_prune)
+
+    def _get_subchannel_index(self, channel_number, base_channel=None) -> int:
+        """Extract subchannel index from channel_number using string parsing, not float math.
+
+        Examples: "90.1" -> 1, "90.11" -> 11, "90.21" -> 21
+        Float input is accepted; Python's str() gives the shortest decimal form.
+        """
+        s = str(channel_number)
+        if '.' in s:
+            try:
+                return int(s.split('.', 1)[1])
+            except (ValueError, IndexError):
+                return 1
+        return 1
+
+    def _cache_bust_image_url(self, url, enabled: bool = True, timestamp=None):
+        """Append or replace a ytarr_ts query parameter on an image URL.
+
+        Returns the original value unchanged when url is blank, a data URI,
+        a local path, or cache-busting is disabled.
+        """
+        if not url:
+            return url
+        if not enabled:
+            return url
+        if isinstance(url, str) and url.startswith(('data:', '/', 'file:')):
+            return url
+        ts = str(int(timestamp)) if timestamp is not None else str(int(time.time()))
+        if '?' in url:
+            base, query = url.split('?', 1)
+            params = [p for p in query.split('&') if p and not p.startswith('ytarr_ts=')]
+            params.append(f'ytarr_ts={ts}')
+            return base + '?' + '&'.join(params)
+        return f'{url}?ytarr_ts={ts}'
+
+    def _merge_youtubearr_custom_properties(self, existing, **metadata) -> dict:
+        """Return a new dict with YouTubearr ownership fields merged into existing props.
+
+        Stamps owner='youtubearr' and any additional metadata kwargs.
+        Does not mutate the input dict. Safe against None or non-dict input.
+        Only call on Stream/ProgramData — Channel and EPGSource lack custom_properties.
+        """
+        result: dict = {}
+        if existing:
+            try:
+                result = dict(existing)
+            except (TypeError, ValueError):
+                pass
+        result['owner'] = 'youtubearr'
+        result.update(metadata)
+        return result
+
+    def _get_custom_m3u_account(self):
+        """Return the custom/built-in M3UAccount for stream association.
+
+        Uses a lazy import so local unit tests without Dispatcharr installed
+        never fail at import time. Returns None on any failure.
+        """
+        try:
+            from apps.m3u.models import M3UAccount  # noqa: PLC0415
+            try:
+                return M3UAccount.get_custom_account()
+            except AttributeError:
+                account, _ = M3UAccount.objects.get_or_create(
+                    name='custom',
+                    defaults={'is_active': True, 'locked': True, 'max_streams': 0},
+                )
+                return account
+        except ImportError:
+            return None
+        except Exception:
+            return None
 
     # --- XMLTV Cache Generation ---
 
@@ -2598,58 +3013,145 @@ class Plugin:
         except Exception as e:
             self._log_error(f"Failed to generate XMLTV cache: {e}")
 
-    # --- Logging ---
+    # --- Webhook / Notification ---
+
+    def _parse_webhook_headers(self, raw: str) -> Dict[str, str]:
+        """Safely parse a JSON object string into a header dict. Invalid input is logged and ignored."""
+        if not raw or not isinstance(raw, str):
+            return {}
+        raw = raw.strip()
+        if not raw:
+            return {}
+        try:
+            parsed = json.loads(raw)
+            if not isinstance(parsed, dict):
+                self._log_error("Webhook headers must be a JSON object string; ignoring")
+                return {}
+            return {str(k): str(v) for k, v in parsed.items()}
+        except json.JSONDecodeError as exc:
+            self._log_error(f"Invalid webhook headers JSON (ignored): {exc}")
+            return {}
+
+    def _get_media_refresh_webhook_config(self, settings: Dict[str, Any]) -> Dict[str, Any]:
+        """Resolve media refresh webhook settings. New keys take precedence over legacy ones."""
+        new_url = settings.get("media_refresh_webhook_url", "").strip()
+        legacy_url = settings.get("webhook_url", "").strip()
+        url = new_url or legacy_url
+        is_legacy = bool(legacy_url and not new_url)
+
+        raw_delay = settings.get("media_refresh_webhook_delay_seconds",
+                                  settings.get("webhook_delay_seconds", 5))
+        try:
+            delay = max(0, min(60, int(raw_delay)))
+        except (TypeError, ValueError):
+            delay = 5
+
+        return {
+            "url": url,
+            "method": settings.get("media_refresh_webhook_method", "POST"),
+            "delay": delay,
+            "headers": self._parse_webhook_headers(settings.get("media_refresh_webhook_headers", "")),
+            "body_template": settings.get("media_refresh_webhook_body_template", ""),
+            "is_legacy": is_legacy,
+        }
+
+    def _get_notification_webhook_config(self, settings: Dict[str, Any]) -> Dict[str, Any]:
+        """Resolve notification webhook settings. New keys take precedence over legacy ones."""
+        new_url = settings.get("notification_webhook_url", "").strip()
+        legacy_url = settings.get("telegram_webhook_url", "").strip()
+        url = new_url or legacy_url
+        is_legacy = bool(legacy_url and not new_url)
+
+        new_base = settings.get("notification_base_url", "").strip().rstrip("/")
+        legacy_base = settings.get("dispatcharr_base_url", "").strip().rstrip("/")
+        base_url = new_base or legacy_base
+
+        return {
+            "url": url,
+            "method": settings.get("notification_webhook_method", "POST"),
+            "headers": self._parse_webhook_headers(settings.get("notification_webhook_headers", "")),
+            "base_url": base_url,
+            "is_legacy": is_legacy,
+        }
+
+    def _send_webhook_request(self, url: str, method: str = 'POST',
+                               headers: Optional[Dict[str, str]] = None,
+                               body: Optional[str] = None, timeout: int = 10) -> tuple:
+        """Send a single webhook HTTP request. Returns (status, response_text). May raise."""
+        data = body.encode('utf-8') if isinstance(body, str) else None
+        req = urllib.request.Request(url, data=data, method=method)
+        req.add_header('Content-Type', 'application/json')
+        if headers:
+            for k, v in headers.items():
+                req.add_header(k, str(v))
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            return response.status, response.read().decode('utf-8', errors='replace')
+
+    def _send_webhook_async(self, kind: str, url: str, method: str,
+                             headers: Optional[Dict[str, str]], body: Optional[str],
+                             delay_seconds: int = 0) -> None:
+        """Fire a webhook in a short-lived daemon thread. Never blocks the caller."""
+        def _worker():
+            try:
+                if delay_seconds > 0:
+                    self._log(f"[{kind}] Waiting {delay_seconds}s before sending webhook...")
+                    time.sleep(delay_seconds)
+                self._log(f"[{kind}] Sending webhook: {url}")
+                status, _ = self._send_webhook_request(url, method=method,
+                                                        headers=headers, body=body, timeout=10)
+                if status in [200, 201, 204]:
+                    self._log(f"[{kind}] Webhook sent successfully (HTTP {status})")
+                else:
+                    self._log(f"[{kind}] Webhook returned HTTP {status}")
+            except Exception as exc:
+                self._log_error(f"[{kind}] Webhook failed: {exc}")
+
+        t = threading.Thread(target=_worker, daemon=True)
+        t.start()
 
     def _trigger_webhook(self, settings: Dict[str, Any]) -> None:
-        """Trigger webhook URL when channels change (with configurable delay)"""
+        """Trigger media refresh webhook when channels change. Returns immediately (non-blocking)."""
         # Generate XMLTV cache before triggering webhook so Jellyfin has fresh data
         self._generate_xmltv_cache(settings)
-        webhook_url = settings.get("webhook_url", "").strip()
 
-        if not webhook_url:
-            return  # Webhook disabled
+        config = self._get_media_refresh_webhook_config(settings)
+        url = config["url"]
+        if not url:
+            return
 
-        # Get delay setting (default 5 seconds to let Dispatcharr finish processing)
-        delay_seconds = settings.get("webhook_delay_seconds", 5)
-        try:
-            delay_seconds = int(delay_seconds)
-            if delay_seconds < 0:
-                delay_seconds = 0
-            elif delay_seconds > 60:
-                delay_seconds = 60
-        except (TypeError, ValueError):
-            delay_seconds = 5
+        if config["body_template"]:
+            body = config["body_template"]
+        elif config["is_legacy"]:
+            # Legacy Jellyfin-style: bodyless POST
+            body = None
+        else:
+            body = json.dumps({
+                "event": "media_refresh_requested",
+                "plugin": "youtubearr",
+                "reason": "streams_changed",
+                "timestamp": datetime.now(dt_timezone.utc).isoformat(),
+            })
 
-        try:
-            if delay_seconds > 0:
-                self._log(f"Waiting {delay_seconds}s before triggering webhook...")
-                time.sleep(delay_seconds)
+        self._send_webhook_async(
+            "media_refresh", url, config["method"], config["headers"], body,
+            delay_seconds=config["delay"],
+        )
 
-            self._log(f"Triggering webhook: {webhook_url}")
-            req = urllib.request.Request(webhook_url, method='POST')
-            req.add_header('Content-Type', 'application/json')
+    def _send_telegram_notification(self, settings: Dict[str, Any], video_id: str,
+                                     metadata: Dict[str, Any], channel_number: int,
+                                     channel_uuid: str) -> None:
+        """Send notification webhook when a new channel is added."""
+        config = self._get_notification_webhook_config(settings)
+        url = config["url"]
+        if not url:
+            return
 
-            with urllib.request.urlopen(req, timeout=10) as response:
-                status = response.status
-                if status in [200, 204]:
-                    self._log(f"Webhook triggered successfully (HTTP {status})")
-                else:
-                    self._log(f"Webhook returned HTTP {status}")
-        except Exception as exc:
-            self._log_error(f"Failed to trigger webhook: {exc}")
+        base_url = config["base_url"]
 
-    def _send_telegram_notification(self, settings: Dict[str, Any], video_id: str, metadata: Dict[str, Any], channel_number: int, channel_uuid: str) -> None:
-        """Send Telegram notification when a new channel is added"""
-        telegram_url = settings.get("telegram_webhook_url", "").strip()
-
-        if not telegram_url:
-            return  # Telegram notifications disabled
-
-        try:
-            # Build the payload for Claudia (use channel UUID for Dispatcharr stream URL)
-            base_url = settings.get("dispatcharr_base_url", "").strip().rstrip("/")
+        if config["is_legacy"]:
+            # Legacy Telegram payload — preserve exact key shape
             if not base_url:
-                self._log("Skipping Telegram notification: dispatcharr_base_url not configured")
+                self._log("Skipping notification: base URL not configured")
                 return
             dispatcharr_url = f"{base_url}/proxy/ts/stream/{channel_uuid}"
             payload = {
@@ -2657,23 +3159,29 @@ class Plugin:
                 "channel": metadata.get("youtube_channel_name", "YouTube"),
                 "url": dispatcharr_url,
                 "description": f"Added as Dispatcharr Channel #{channel_number}",
-                "timestamp": datetime.now(dt_timezone.utc).isoformat()
+                "timestamp": datetime.now(dt_timezone.utc).isoformat(),
+            }
+        else:
+            # Generic notification payload
+            dispatcharr_url = f"{base_url}/proxy/ts/stream/{channel_uuid}" if base_url else ""
+            payload = {
+                "event": "stream_added",
+                "plugin": "youtubearr",
+                "video_id": video_id,
+                "title": metadata.get("title", "YouTube Live Stream"),
+                "channel_name": metadata.get("youtube_channel_name", "YouTube"),
+                "channel_number": str(channel_number),
+                "dispatcharr_channel_uuid": channel_uuid,
+                "url": dispatcharr_url,
+                "thumbnail": metadata.get("thumbnail", ""),
+                "timestamp": datetime.now(dt_timezone.utc).isoformat(),
             }
 
-            self._log(f"Sending Telegram notification for: {metadata.get('title', 'stream')[:60]}...")
-
-            data = json.dumps(payload).encode('utf-8')
-            req = urllib.request.Request(telegram_url, data=data, method='POST')
-            req.add_header('Content-Type', 'application/json')
-
-            with urllib.request.urlopen(req, timeout=10) as response:
-                status = response.status
-                if status in [200, 201, 204]:
-                    self._log(f"Telegram notification sent successfully (HTTP {status})")
-                else:
-                    self._log_error(f"Telegram notification failed: HTTP {status} from {telegram_url}")
-        except Exception as exc:
-            self._log_error(f"Failed to send Telegram notification: {exc}")
+        self._log(f"Sending notification for: {metadata.get('title', 'stream')[:60]}...")
+        self._send_webhook_async(
+            "notification", url, config["method"], config["headers"],
+            json.dumps(payload), delay_seconds=0,
+        )
 
     # --- Celery Beat Scheduling ---
 

--- a/plugin.py
+++ b/plugin.py
@@ -19,7 +19,7 @@ from apps.plugins.models import PluginConfig
 from apps.channels.models import Channel, ChannelGroup, ChannelStream, Stream, Logo, ChannelProfile, ChannelProfileMembership
 from apps.epg.models import EPGData, EPGSource, ProgramData
 from core.models import StreamProfile
-from core.scheduling import create_or_update_periodic_task, delete_periodic_task
+from core.scheduling import delete_periodic_task
 
 
 class Plugin:
@@ -370,6 +370,8 @@ class Plugin:
         # Track video IDs that recently failed metadata extraction to avoid retrying every poll
         self._extraction_failures: Dict[str, float] = {}  # video_id -> unix timestamp of failure
 
+        self._legacy_task_cleanup_done = False
+
         # Field defaults
         self._field_defaults = {field["id"]: field.get("default") for field in self.fields}
 
@@ -426,8 +428,7 @@ class Plugin:
 
     def _handle_status(self, context: Dict[str, Any]) -> Dict[str, Any]:
         """Return current status"""
-        # IMPORTANT: Always read fresh settings from DB for auto-restart check
-        # Context settings may be stale (e.g., from Celery beat health check)
+        # Always read fresh settings from DB for auto-restart check
         try:
             cfg = PluginConfig.objects.get(key=self._plugin_key)
             settings = dict(cfg.settings or {})
@@ -437,6 +438,10 @@ class Plugin:
         tracked_streams = settings.get("tracked_streams", {})
         monitoring_active = settings.get("monitoring_active", False)
 
+        # Clean up the bogus Celery beat task left by older plugin versions (once per instance)
+        # Must run before any early return, so it fires even when yt-dlp is missing.
+        self._cleanup_legacy_celery_task()
+
         # Check yt-dlp availability
         if not self._ytdlp_path:
             return {
@@ -444,47 +449,8 @@ class Plugin:
                 "message": "yt-dlp not found (bundled version may not be working). Check logs.",
             }
 
-        # Auto-restart monitoring if DB says active but no thread is actually running
-        # This handles container/service restarts AND crashed/hung threads
-        # IMPORTANT: We can't rely on self._monitor_thread because each Celery worker
-        # creates a new Plugin instance with _monitor_thread=None. Instead, we check
-        # the monitoring_heartbeat timestamp to see if a thread is actively polling.
-        thread_dead = not self._monitor_thread or not self._monitor_thread.is_alive()
-
-        # Check if another thread is actually running by looking at heartbeat
-        heartbeat_str = settings.get("monitoring_heartbeat")
-        heartbeat_recent = False
-        if heartbeat_str:
-            try:
-                heartbeat = datetime.fromisoformat(heartbeat_str.replace("Z", "+00:00"))
-                if isinstance(heartbeat.tzinfo, type(None)):
-                    heartbeat = heartbeat.replace(tzinfo=dt_timezone.utc)
-                age_seconds = (datetime.now(dt_timezone.utc) - heartbeat).total_seconds()
-                # Heartbeat threshold must be longer than poll_interval + poll_duration
-                # Poll cycles can take 5-10 minutes with many channels, so use poll_interval + 10 min buffer
-                poll_interval_minutes = settings.get("poll_interval_minutes", 15)
-                heartbeat_threshold = (poll_interval_minutes + 10) * 60  # e.g., 25 minutes for 15-min poll
-                heartbeat_recent = age_seconds < heartbeat_threshold
-                if heartbeat_recent:
-                    self._log(f"Monitoring heartbeat is recent ({int(age_seconds)}s ago, threshold={heartbeat_threshold}s), skipping auto-restart")
-            except (ValueError, TypeError):
-                pass
-
-        if monitoring_active and thread_dead and not heartbeat_recent:
-            channels = settings.get("monitored_channels", "").strip()
-            if channels and self._ytdlp_path:
-                self._log("Auto-restarting monitoring after service restart")
-                self._monitoring_active = True
-                self._monitor_stop_event.clear()
-                self._monitor_thread = threading.Thread(
-                    target=self._monitoring_loop,
-                    args=(self._plugin_key,),
-                    daemon=True,
-                    name="YouTubearr-Monitor"
-                )
-                self._monitor_thread.start()
-                # Ensure Celery beat health check is registered (idempotent)
-                self._register_celery_health_check()
+        # Self-heal: restart the monitor thread if DB says active but no live thread exists
+        self._ensure_monitoring_thread(settings)
 
         message_parts = []
         if monitoring_active:
@@ -731,9 +697,7 @@ class Plugin:
         self._monitor_thread.start()
 
         self._log("Monitoring started")
-
-        # Register Celery beat health check for auto-recovery
-        self._register_celery_health_check()
+        self._cleanup_legacy_celery_task()
 
         return {
             "status": "running",
@@ -766,9 +730,7 @@ class Plugin:
             self._monitor_thread.join(timeout=5.0)
 
         self._log("Monitoring stopped")
-
-        # Unregister Celery beat health check
-        self._unregister_celery_health_check()
+        self._cleanup_legacy_celery_task()
 
         return {
             "status": "stopped",
@@ -1035,6 +997,46 @@ class Plugin:
             if isinstance(details.get(key), str) and "unavailable" in details[key]:
                 issues.append(f"warning:{key} count unavailable")
         details["epg_counts"] = self._get_epg_counts(settings)
+
+        # Legacy Celery beat task presence
+        try:
+            from django_celery_beat.models import PeriodicTask as _PT
+            _task_name = f"youtubearr_{self._plugin_key}_health_check"
+            present = _PT.objects.filter(name=_task_name).exists()
+            details["legacy_celery_health_check_present"] = present
+            if present:
+                issues.append("warning:legacy Celery beat task present — causes unregistered-task spam; will auto-remove on next status/start action")
+        except Exception as _exc:
+            details["legacy_celery_health_check_present"] = f"unavailable: {_exc}"
+
+        # Stale stream URLs (live streams whose URL hasn't been refreshed recently)
+        _url_refresh_interval = settings.get("url_refresh_interval_seconds", 3600)
+        _stale_threshold = 2 * _url_refresh_interval
+        _now_utc = datetime.now(dt_timezone.utc)
+        stale_count = 0
+        oldest_stale_age = 0.0
+        for _vid, _sd in tracked_streams.items():
+            if not _sd.get("is_live"):
+                continue
+            _last_str = _sd.get("last_url_refresh")
+            if not _last_str:
+                stale_count += 1
+                continue
+            try:
+                _lr = datetime.fromisoformat(_last_str.replace("Z", "+00:00"))
+                if _lr.tzinfo is None:
+                    _lr = _lr.replace(tzinfo=dt_timezone.utc)
+                _age = (_now_utc - _lr).total_seconds()
+                if _age > _stale_threshold:
+                    stale_count += 1
+                    oldest_stale_age = max(oldest_stale_age, _age)
+            except (ValueError, TypeError):
+                stale_count += 1
+        details["stale_tracked_stream_url_count"] = stale_count
+        if oldest_stale_age:
+            details["oldest_url_refresh_age_seconds"] = int(oldest_stale_age)
+        if stale_count > 0:
+            issues.append(f"warning:{stale_count} live stream URL(s) are stale (monitor may not be refreshing URLs)")
 
         # Recent log summary
         details["log_summary"] = self._get_recent_log_summary()
@@ -3183,32 +3185,72 @@ class Plugin:
             json.dumps(payload), delay_seconds=0,
         )
 
-    # --- Celery Beat Scheduling ---
+    # --- Monitoring Self-Healing and Legacy Cleanup ---
 
-    def _register_celery_health_check(self) -> None:
-        """Register periodic health check with Celery beat (runs every 5 minutes)"""
-        try:
-            task_name = f"youtubearr_{self._plugin_key}_health_check"
-            create_or_update_periodic_task(
-                task_name=task_name,
-                celery_task_path="core.tasks.check_plugin_health",
-                kwargs={"plugin_key": self._plugin_key},
-                cron_expression="*/5 * * * *",  # Every 5 minutes
-                enabled=True,
-            )
-            self._log(f"Registered Celery beat health check: {task_name}")
-        except Exception as exc:
-            self._log_error(f"Failed to register Celery health check: {exc}")
+    def _cleanup_legacy_celery_task(self) -> None:
+        """Delete the bogus Celery beat task registered by older plugin versions.
 
-    def _unregister_celery_health_check(self) -> None:
-        """Unregister periodic health check from Celery beat"""
+        Older versions registered a periodic task pointing at a Dispatcharr core task
+        that does not exist, causing Celery to spam 'Received unregistered task' errors
+        every 5 minutes. This method is idempotent (runs once per Plugin instance) and
+        safe to call from any action handler.
+        """
+        if self._legacy_task_cleanup_done:
+            return
+        self._legacy_task_cleanup_done = True
         try:
             task_name = f"youtubearr_{self._plugin_key}_health_check"
             deleted = delete_periodic_task(task_name)
             if deleted:
-                self._log(f"Unregistered Celery beat health check: {task_name}")
+                self._log(f"Removed legacy Celery beat task: {task_name}")
         except Exception as exc:
-            self._log_error(f"Failed to unregister Celery health check: {exc}")
+            self._log_error(f"Legacy Celery task cleanup failed: {exc}")
+
+    def _ensure_monitoring_thread(self, settings: Dict[str, Any]) -> bool:
+        """Restart the monitor thread if DB says active but no live thread is running.
+
+        This is the in-plugin self-healing path: it handles container restarts and
+        crashed/hung threads without relying on any Celery task. Returns True if a
+        new thread was started.
+        """
+        if not settings.get("monitoring_active"):
+            return False
+
+        thread_dead = not self._monitor_thread or not self._monitor_thread.is_alive()
+        if not thread_dead:
+            return False
+
+        # Another Celery worker's thread may still be running — check the shared heartbeat
+        heartbeat_str = settings.get("monitoring_heartbeat")
+        if heartbeat_str:
+            try:
+                heartbeat = datetime.fromisoformat(heartbeat_str.replace("Z", "+00:00"))
+                if isinstance(heartbeat.tzinfo, type(None)):
+                    heartbeat = heartbeat.replace(tzinfo=dt_timezone.utc)
+                age_seconds = (datetime.now(dt_timezone.utc) - heartbeat).total_seconds()
+                poll_interval_minutes = settings.get("poll_interval_minutes", 15)
+                heartbeat_threshold = (poll_interval_minutes + 10) * 60
+                if age_seconds < heartbeat_threshold:
+                    self._log(f"Monitoring heartbeat is recent ({int(age_seconds)}s ago, threshold={heartbeat_threshold}s), skipping auto-restart")
+                    return False
+            except (ValueError, TypeError):
+                pass
+
+        channels = settings.get("monitored_channels", "").strip()
+        if not channels or not self._ytdlp_path:
+            return False
+
+        self._log("Auto-restarting monitoring after service restart")
+        self._monitoring_active = True
+        self._monitor_stop_event.clear()
+        self._monitor_thread = threading.Thread(
+            target=self._monitoring_loop,
+            args=(self._plugin_key,),
+            daemon=True,
+            name="YouTubearr-Monitor"
+        )
+        self._monitor_thread.start()
+        return True
 
     def _log(self, message: str) -> None:
         """Write log message"""

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1113,5 +1113,365 @@ class TestGetRecentLogSummary(unittest.TestCase):
             tmp_path.unlink(missing_ok=True)
 
 
+class TestCeleryCleanup(unittest.TestCase):
+    """Legacy Celery beat task is removed and never re-registered."""
+
+    def _make_p(self):
+        p = _make_plugin()
+        p._plugin_key = "youtubearr"
+        p._monitor_thread = None
+        p._monitoring_active = False
+        p._monitor_stop_event = MagicMock()
+        p._legacy_task_cleanup_done = False
+        return p
+
+    def test_create_or_update_not_in_plugin_namespace(self):
+        """create_or_update_periodic_task must not be imported — it would create the bogus task."""
+        import plugin as plugin_module
+        self.assertFalse(
+            hasattr(plugin_module, "create_or_update_periodic_task"),
+            "create_or_update_periodic_task must not appear in plugin.py",
+        )
+
+    def test_cleanup_calls_delete_with_correct_task_name(self):
+        p = self._make_p()
+        with patch("plugin.delete_periodic_task", return_value=True) as mock_del:
+            p._cleanup_legacy_celery_task()
+        mock_del.assert_called_once_with("youtubearr_youtubearr_health_check")
+
+    def test_cleanup_is_idempotent(self):
+        p = self._make_p()
+        with patch("plugin.delete_periodic_task", return_value=True) as mock_del:
+            p._cleanup_legacy_celery_task()
+            p._cleanup_legacy_celery_task()
+            p._cleanup_legacy_celery_task()
+        self.assertEqual(mock_del.call_count, 1)
+
+    def test_cleanup_swallows_db_exception(self):
+        p = self._make_p()
+        error_messages = []
+        p._log_error = lambda message: error_messages.append(message)
+        with patch("plugin.delete_periodic_task", side_effect=RuntimeError("DB down")):
+            p._cleanup_legacy_celery_task()  # must not raise
+        self.assertTrue(any("cleanup" in m.lower() for m in error_messages))
+
+    def test_cleanup_logs_when_task_deleted(self):
+        p = self._make_p()
+        messages = []
+        p._log = lambda m: messages.append(m)
+        with patch("plugin.delete_periodic_task", return_value=True):
+            p._cleanup_legacy_celery_task()
+        self.assertTrue(any("legacy" in m.lower() or "removed" in m.lower() for m in messages))
+
+    def test_cleanup_no_log_when_task_absent(self):
+        p = self._make_p()
+        messages = []
+        p._log = lambda m: messages.append(m)
+        with patch("plugin.delete_periodic_task", return_value=False):
+            p._cleanup_legacy_celery_task()
+        self.assertFalse(messages)
+
+    def test_handle_status_calls_cleanup(self):
+        p = self._make_p()
+        p._ytdlp_path = "/usr/bin/yt-dlp"
+        cleanup_calls = []
+        p._cleanup_legacy_celery_task = lambda: cleanup_calls.append(True)
+        p._ensure_monitoring_thread = MagicMock(return_value=False)
+        with patch("plugin.PluginConfig") as mock_cfg:
+            mock_cfg.DoesNotExist = type("DoesNotExist", (Exception,), {})
+            mock_cfg.objects.get.side_effect = mock_cfg.DoesNotExist
+            p._handle_status({"settings": {}})
+        self.assertTrue(cleanup_calls)
+
+    def test_handle_status_missing_ytdlp_still_calls_cleanup(self):
+        """Even when yt-dlp is unavailable, _handle_status must call cleanup before returning early."""
+        p = self._make_p()
+        p._ytdlp_path = None  # missing yt-dlp triggers early return
+        cleanup_calls = []
+        p._cleanup_legacy_celery_task = lambda: cleanup_calls.append(True)
+        p._ensure_monitoring_thread = MagicMock(return_value=False)
+        with patch("plugin.PluginConfig") as mock_cfg:
+            mock_cfg.DoesNotExist = type("DoesNotExist", (Exception,), {})
+            mock_cfg.objects.get.side_effect = mock_cfg.DoesNotExist
+            result = p._handle_status({"settings": {}})
+        self.assertTrue(cleanup_calls, "cleanup must run even when yt-dlp is missing")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("yt-dlp", result.get("message", ""))
+
+    def test_handle_start_monitoring_calls_cleanup(self):
+        p = self._make_p()
+        p._ytdlp_path = "/usr/bin/yt-dlp"
+        cleanup_calls = []
+        p._cleanup_legacy_celery_task = lambda: cleanup_calls.append(True)
+        p._persist_settings = MagicMock()
+        with patch("plugin.PluginConfig") as mock_cfg:
+            mock_cfg.DoesNotExist = type("DoesNotExist", (Exception,), {})
+            mock_cfg.objects.get.side_effect = mock_cfg.DoesNotExist
+            with patch("threading.Thread") as mock_thread:
+                mock_thread.return_value.is_alive.return_value = False
+                p._handle_start_monitoring({"settings": {"monitored_channels": "@nasa"}})
+        self.assertTrue(cleanup_calls)
+
+    def test_handle_stop_monitoring_calls_cleanup(self):
+        p = self._make_p()
+        p._ytdlp_path = "/usr/bin/yt-dlp"
+        p._monitoring_active = True
+        cleanup_calls = []
+        p._cleanup_legacy_celery_task = lambda: cleanup_calls.append(True)
+        p._persist_settings = MagicMock()
+        with patch("plugin.PluginConfig") as mock_cfg:
+            mock_cfg.DoesNotExist = type("DoesNotExist", (Exception,), {})
+            mock_cfg.objects.get.side_effect = mock_cfg.DoesNotExist
+            p._handle_stop_monitoring({"settings": {"monitoring_active": True}})
+        self.assertTrue(cleanup_calls)
+
+
+class TestEnsureMonitoringThread(unittest.TestCase):
+    """_ensure_monitoring_thread self-heals without Celery."""
+
+    def _make_p(self):
+        p = _make_plugin()
+        p._plugin_key = "youtubearr"
+        p._monitor_thread = None
+        p._monitoring_active = False
+        p._monitor_stop_event = MagicMock()
+        p._legacy_task_cleanup_done = False
+        return p
+
+    def test_returns_false_when_monitoring_inactive(self):
+        p = self._make_p()
+        started = p._ensure_monitoring_thread({"monitoring_active": False})
+        self.assertFalse(started)
+        self.assertIsNone(p._monitor_thread)
+
+    def test_starts_thread_when_db_active_and_thread_dead(self):
+        p = self._make_p()
+        settings = {"monitoring_active": True, "monitored_channels": "@nasa"}
+        with patch("threading.Thread") as mock_thread:
+            mock_thread.return_value.is_alive.return_value = False
+            started = p._ensure_monitoring_thread(settings)
+        self.assertTrue(started)
+        self.assertTrue(p._monitoring_active)
+
+    def test_skips_when_heartbeat_is_recent(self):
+        from datetime import datetime, timezone as dt_timezone
+        p = self._make_p()
+        recent_hb = datetime.now(dt_timezone.utc).isoformat()
+        settings = {
+            "monitoring_active": True,
+            "monitored_channels": "@nasa",
+            "monitoring_heartbeat": recent_hb,
+            "poll_interval_minutes": 15,
+        }
+        started = p._ensure_monitoring_thread(settings)
+        self.assertFalse(started)
+        self.assertIsNone(p._monitor_thread)
+
+    def test_restarts_when_heartbeat_is_stale(self):
+        from datetime import datetime, timezone as dt_timezone, timedelta
+        p = self._make_p()
+        stale_hb = (datetime.now(dt_timezone.utc) - timedelta(hours=2)).isoformat()
+        settings = {
+            "monitoring_active": True,
+            "monitored_channels": "@nasa",
+            "monitoring_heartbeat": stale_hb,
+            "poll_interval_minutes": 15,
+        }
+        with patch("threading.Thread") as mock_thread:
+            mock_thread.return_value.is_alive.return_value = False
+            started = p._ensure_monitoring_thread(settings)
+        self.assertTrue(started)
+
+    def test_skips_when_no_channels_configured(self):
+        p = self._make_p()
+        settings = {"monitoring_active": True, "monitored_channels": ""}
+        started = p._ensure_monitoring_thread(settings)
+        self.assertFalse(started)
+
+    def test_skips_when_ytdlp_missing(self):
+        p = self._make_p()
+        p._ytdlp_path = None
+        settings = {"monitoring_active": True, "monitored_channels": "@nasa"}
+        started = p._ensure_monitoring_thread(settings)
+        self.assertFalse(started)
+
+    def test_skips_when_thread_already_alive(self):
+        p = self._make_p()
+        alive_thread = MagicMock()
+        alive_thread.is_alive.return_value = True
+        p._monitor_thread = alive_thread
+        settings = {"monitoring_active": True, "monitored_channels": "@nasa"}
+        started = p._ensure_monitoring_thread(settings)
+        self.assertFalse(started)
+
+
+class TestDiagnosticsNewFields(unittest.TestCase):
+    """Diagnostics surfaces legacy Celery task and stale URL count."""
+
+    def _make_p(self):
+        p = _make_plugin()
+        p._plugin_key = "youtubearr"
+        p._monitor_thread = None
+        p._monitoring_active = False
+        p._legacy_task_cleanup_done = False
+        p._log_path = MagicMock()
+        p._log_path.exists.return_value = False
+        p._base_dir = MagicMock()
+        p._get_ytdlp_version = MagicMock(return_value="2025.01.01")
+        p._get_qjs_version = MagicMock(return_value="not configured")
+        return p
+
+    def test_legacy_celery_field_always_present(self):
+        p = self._make_p()
+        result = p._handle_diagnostics({"settings": {}})
+        self.assertIn("legacy_celery_health_check_present", result["details"])
+
+    def test_legacy_celery_field_unavailable_when_no_beat_package(self):
+        """Without django-celery-beat installed the field is an unavailable string."""
+        p = self._make_p()
+        # django_celery_beat is not in sys.modules by default in the test environment
+        result = p._handle_diagnostics({"settings": {}})
+        val = result["details"]["legacy_celery_health_check_present"]
+        # Must be either a bool (if package happened to be available) or a string
+        self.assertIsInstance(val, (bool, str))
+
+    def test_legacy_celery_warns_when_task_present(self):
+        p = self._make_p()
+        mock_pt = MagicMock()
+        mock_pt.objects.filter.return_value.exists.return_value = True
+        mock_beat_models = MagicMock()
+        mock_beat_models.PeriodicTask = mock_pt
+        with patch.dict(sys.modules, {
+            "django_celery_beat": MagicMock(),
+            "django_celery_beat.models": mock_beat_models,
+        }):
+            result = p._handle_diagnostics({"settings": {}})
+        self.assertTrue(result["details"]["legacy_celery_health_check_present"])
+        self.assertIn(result["status"], ("warning", "error"))
+
+    def test_legacy_celery_no_warning_when_task_absent(self):
+        p = self._make_p()
+        mock_pt = MagicMock()
+        mock_pt.objects.filter.return_value.exists.return_value = False
+        mock_beat_models = MagicMock()
+        mock_beat_models.PeriodicTask = mock_pt
+        with patch.dict(sys.modules, {
+            "django_celery_beat": MagicMock(),
+            "django_celery_beat.models": mock_beat_models,
+        }):
+            result = p._handle_diagnostics({"settings": {}})
+        self.assertFalse(result["details"]["legacy_celery_health_check_present"])
+
+    def test_stale_url_count_zero_when_no_live_streams(self):
+        p = self._make_p()
+        settings = {"tracked_streams": {"v1": {"is_live": False}}}
+        result = p._handle_diagnostics({"settings": settings})
+        self.assertEqual(result["details"]["stale_tracked_stream_url_count"], 0)
+
+    def test_stale_url_count_one_for_live_stream_with_no_refresh_timestamp(self):
+        p = self._make_p()
+        settings = {"tracked_streams": {"v1": {"is_live": True}}}
+        result = p._handle_diagnostics({"settings": settings})
+        self.assertEqual(result["details"]["stale_tracked_stream_url_count"], 1)
+        self.assertIn(result["status"], ("warning", "error"))
+
+    def test_stale_url_count_for_old_refresh(self):
+        from datetime import datetime, timezone as dt_timezone, timedelta
+        p = self._make_p()
+        old_ts = (datetime.now(dt_timezone.utc) - timedelta(hours=6)).isoformat()
+        settings = {
+            "url_refresh_interval_seconds": 3600,
+            "tracked_streams": {"v1": {"is_live": True, "last_url_refresh": old_ts}},
+        }
+        result = p._handle_diagnostics({"settings": settings})
+        self.assertGreater(result["details"]["stale_tracked_stream_url_count"], 0)
+        self.assertIn("oldest_url_refresh_age_seconds", result["details"])
+
+    def test_stale_url_count_zero_for_fresh_stream(self):
+        from datetime import datetime, timezone as dt_timezone
+        p = self._make_p()
+        now_ts = datetime.now(dt_timezone.utc).isoformat()
+        settings = {
+            "url_refresh_interval_seconds": 3600,
+            "tracked_streams": {"v1": {"is_live": True, "last_url_refresh": now_ts}},
+        }
+        result = p._handle_diagnostics({"settings": settings})
+        self.assertEqual(result["details"]["stale_tracked_stream_url_count"], 0)
+
+    def test_stale_url_invalid_timestamp_counts_as_stale(self):
+        p = self._make_p()
+        settings = {"tracked_streams": {"v1": {"is_live": True, "last_url_refresh": "bad-ts"}}}
+        result = p._handle_diagnostics({"settings": settings})
+        self.assertEqual(result["details"]["stale_tracked_stream_url_count"], 1)
+
+
+class TestRefreshExpiringUrls(unittest.TestCase):
+    """_refresh_expiring_urls refreshes stale stream URLs and persists the update."""
+
+    def _make_p(self):
+        p = _make_plugin()
+        p._plugin_key = "youtubearr"
+        p._persist_settings = MagicMock()
+        return p
+
+    def test_refreshes_and_persists_when_url_stale(self):
+        from datetime import datetime, timezone as dt_timezone, timedelta
+        p = self._make_p()
+        old_ts = (datetime.now(dt_timezone.utc) - timedelta(hours=3)).isoformat()
+        stream_data = {
+            "is_live": True,
+            "last_url_refresh": old_ts,
+            "stream_id": 42,
+            "title": "Live Stream",
+        }
+        settings = {
+            "url_refresh_interval_seconds": 3600,
+            "tracked_streams": {"vid1": stream_data},
+        }
+        new_url = "https://refreshed.example.com/stream.m3u8"
+        p._extract_stream_metadata = MagicMock(return_value={"stream_url": new_url})
+        mock_stream = MagicMock()
+        with patch("plugin.Stream") as mock_stream_cls:
+            mock_stream_cls.objects.get.return_value = mock_stream
+            count = p._refresh_expiring_urls(settings)
+        self.assertEqual(count, 1)
+        p._persist_settings.assert_called_once()
+        self.assertEqual(stream_data["stream_url"], new_url)
+
+    def test_skips_non_live_streams(self):
+        p = self._make_p()
+        settings = {
+            "url_refresh_interval_seconds": 3600,
+            "tracked_streams": {"vid1": {"is_live": False, "last_url_refresh": "2020-01-01T00:00:00+00:00"}},
+        }
+        p._extract_stream_metadata = MagicMock()
+        count = p._refresh_expiring_urls(settings)
+        self.assertEqual(count, 0)
+        p._extract_stream_metadata.assert_not_called()
+
+    def test_skips_streams_without_last_url_refresh(self):
+        p = self._make_p()
+        settings = {
+            "url_refresh_interval_seconds": 3600,
+            "tracked_streams": {"vid1": {"is_live": True}},
+        }
+        p._extract_stream_metadata = MagicMock()
+        count = p._refresh_expiring_urls(settings)
+        self.assertEqual(count, 0)
+        p._extract_stream_metadata.assert_not_called()
+
+    def test_no_persist_when_nothing_refreshed(self):
+        from datetime import datetime, timezone as dt_timezone
+        p = self._make_p()
+        now_ts = datetime.now(dt_timezone.utc).isoformat()
+        settings = {
+            "url_refresh_interval_seconds": 3600,
+            "tracked_streams": {"vid1": {"is_live": True, "last_url_refresh": now_ts}},
+        }
+        p._extract_stream_metadata = MagicMock()
+        p._refresh_expiring_urls(settings)
+        p._persist_settings.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -13,7 +13,9 @@ Run with: python -m pytest tests/ -v
 import json
 import subprocess
 import sys
+import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 # ── Mock Django and app imports before loading plugin ────────────────────────
@@ -306,6 +308,809 @@ class TestVersionConsistency(unittest.TestCase):
             content = f.read()
         self.assertIn(version, content,
                       f"Version {version} not mentioned in CHANGELOG.md")
+
+
+# ── _prune_extraction_failures ──────────────────────────────────────────────
+
+class TestExtractionFailurePruning(unittest.TestCase):
+
+    def _plugin_with(self, failures):
+        p = _make_plugin()
+        p._extraction_failures = dict(failures)
+        return p
+
+    def test_old_timestamps_are_pruned(self):
+        now = 1_000_000.0
+        p = self._plugin_with({"vid1": now - 8 * 86400})  # 8 days ago, past 7-day TTL
+        pruned = p._prune_extraction_failures(ttl_days=7, now=now)
+        self.assertEqual(pruned, 1)
+        self.assertNotIn("vid1", p._extraction_failures)
+
+    def test_recent_timestamps_remain(self):
+        now = 1_000_000.0
+        p = self._plugin_with({"vid1": now - 3600})  # 1 hour ago
+        pruned = p._prune_extraction_failures(ttl_days=7, now=now)
+        self.assertEqual(pruned, 0)
+        self.assertIn("vid1", p._extraction_failures)
+
+    def test_malformed_timestamp_pruned_without_crash(self):
+        p = self._plugin_with({"vid1": "not_a_number", "vid2": None, "vid3": {}})
+        pruned = p._prune_extraction_failures(ttl_days=7, now=1_000_000.0)
+        self.assertGreaterEqual(pruned, 0)
+        self.assertNotIn("vid1", p._extraction_failures)
+        self.assertNotIn("vid2", p._extraction_failures)
+        self.assertNotIn("vid3", p._extraction_failures)
+
+    def test_future_timestamps_not_pruned(self):
+        # Members-only streams store failure_time = now + 6*86400 to extend the skip window
+        now = 1_000_000.0
+        future = now + 6 * 86400
+        p = self._plugin_with({"vid1": future})
+        pruned = p._prune_extraction_failures(ttl_days=7, now=now)
+        self.assertEqual(pruned, 0)
+        self.assertIn("vid1", p._extraction_failures)
+
+
+# ── _get_subchannel_index ────────────────────────────────────────────────────
+
+class TestSubchannelIndex(unittest.TestCase):
+
+    def test_single_digit(self):
+        self.assertEqual(_make_plugin()._get_subchannel_index("90.1", 90), 1)
+
+    def test_nine(self):
+        self.assertEqual(_make_plugin()._get_subchannel_index("90.9", 90), 9)
+
+    def test_eleven_no_float_math(self):
+        # Float math gives int(round(0.11 * 10)) = 1 (wrong); string parse gives 11 (correct)
+        self.assertEqual(_make_plugin()._get_subchannel_index("90.11", 90), 11)
+
+    def test_twenty_one_no_float_math(self):
+        # Float math gives int(round(0.21 * 10)) = 2 (wrong); string parse gives 21 (correct)
+        self.assertEqual(_make_plugin()._get_subchannel_index("90.21", 90), 21)
+
+    def test_accepts_float_input(self):
+        # channel_number is stored as float; Python's str() gives the short decimal form
+        # float(f"90.{11}") == 90.11 and str(90.11) == "90.11"
+        self.assertEqual(_make_plugin()._get_subchannel_index(float(f"90.{11}"), 90), 11)
+
+    def test_no_decimal_part_returns_one(self):
+        self.assertEqual(_make_plugin()._get_subchannel_index("90", 90), 1)
+
+
+# ── _cache_bust_image_url ────────────────────────────────────────────────────
+
+class TestCacheBustImageUrl(unittest.TestCase):
+
+    def test_no_query_gets_ytarr_ts(self):
+        result = _make_plugin()._cache_bust_image_url(
+            "http://example.com/img.jpg", enabled=True, timestamp=12345
+        )
+        self.assertTrue(result.startswith("http://example.com/img.jpg?"))
+        self.assertIn("ytarr_ts=12345", result)
+
+    def test_existing_query_appended_with_ampersand(self):
+        result = _make_plugin()._cache_bust_image_url(
+            "http://example.com/img.jpg?size=100", enabled=True, timestamp=12345
+        )
+        self.assertIn("size=100", result)
+        self.assertIn("ytarr_ts=12345", result)
+        self.assertIn("&ytarr_ts=", result)
+
+    def test_existing_ytarr_ts_replaced_not_duplicated(self):
+        result = _make_plugin()._cache_bust_image_url(
+            "http://example.com/img.jpg?ytarr_ts=999", enabled=True, timestamp=12345
+        )
+        self.assertIn("ytarr_ts=12345", result)
+        self.assertNotIn("ytarr_ts=999", result)
+        self.assertEqual(result.count("ytarr_ts="), 1)
+
+    def test_disabled_returns_original_url(self):
+        url = "http://example.com/img.jpg"
+        self.assertEqual(_make_plugin()._cache_bust_image_url(url, enabled=False, timestamp=12345), url)
+
+    def test_blank_string_unchanged(self):
+        self.assertEqual(_make_plugin()._cache_bust_image_url(""), "")
+
+    def test_none_unchanged(self):
+        self.assertIsNone(_make_plugin()._cache_bust_image_url(None))
+
+    def test_data_url_unchanged(self):
+        url = "data:image/png;base64,abc123=="
+        self.assertEqual(_make_plugin()._cache_bust_image_url(url, timestamp=12345), url)
+
+    def test_local_path_unchanged(self):
+        url = "/var/www/img.jpg"
+        self.assertEqual(_make_plugin()._cache_bust_image_url(url, timestamp=12345), url)
+
+
+# ── _merge_youtubearr_custom_properties ─────────────────────────────────────
+
+class TestMergeCustomProperties(unittest.TestCase):
+
+    def test_preserves_existing_props(self):
+        existing = {"foo": "bar", "count": 42}
+        result = _make_plugin()._merge_youtubearr_custom_properties(existing, youtube_video_id="abc")
+        self.assertEqual(result["foo"], "bar")
+        self.assertEqual(result["count"], 42)
+
+    def test_adds_owner_field(self):
+        result = _make_plugin()._merge_youtubearr_custom_properties({})
+        self.assertEqual(result["owner"], "youtubearr")
+
+    def test_adds_metadata_kwargs(self):
+        result = _make_plugin()._merge_youtubearr_custom_properties(
+            {}, youtube_video_id="vid1", youtube_channel_id="chan1"
+        )
+        self.assertEqual(result["youtube_video_id"], "vid1")
+        self.assertEqual(result["youtube_channel_id"], "chan1")
+
+    def test_overwrites_owner_and_video_id(self):
+        existing = {"owner": "other", "youtube_video_id": "old"}
+        result = _make_plugin()._merge_youtubearr_custom_properties(existing, youtube_video_id="new")
+        self.assertEqual(result["owner"], "youtubearr")
+        self.assertEqual(result["youtube_video_id"], "new")
+
+    def test_none_existing_treated_as_empty(self):
+        result = _make_plugin()._merge_youtubearr_custom_properties(None)
+        self.assertEqual(result["owner"], "youtubearr")
+
+    def test_does_not_mutate_input(self):
+        existing = {"foo": "bar"}
+        _make_plugin()._merge_youtubearr_custom_properties(existing, youtube_video_id="vid1")
+        self.assertNotIn("owner", existing)
+        self.assertNotIn("youtube_video_id", existing)
+
+
+# ── _get_custom_m3u_account ──────────────────────────────────────────────────
+
+class TestGetCustomM3uAccount(unittest.TestCase):
+
+    def _clear_m3u_modules(self):
+        for key in list(sys.modules.keys()):
+            if 'm3u' in key:
+                del sys.modules[key]
+
+    def test_returns_none_when_m3u_not_installed(self):
+        self._clear_m3u_modules()
+        result = _make_plugin()._get_custom_m3u_account()
+        self.assertIsNone(result)
+
+    def test_calls_get_custom_account_when_available(self):
+        mock_account = MagicMock()
+        mock_module = MagicMock()
+        mock_module.M3UAccount.get_custom_account.return_value = mock_account
+        with patch.dict('sys.modules', {'apps.m3u': MagicMock(), 'apps.m3u.models': mock_module}):
+            result = _make_plugin()._get_custom_m3u_account()
+        self.assertEqual(result, mock_account)
+
+    def test_fallback_get_or_create_when_get_custom_account_absent(self):
+        mock_account = MagicMock()
+        mock_module = MagicMock()
+        mock_module.M3UAccount.get_custom_account.side_effect = AttributeError("no method")
+        mock_module.M3UAccount.objects.get_or_create.return_value = (mock_account, True)
+        with patch.dict('sys.modules', {'apps.m3u': MagicMock(), 'apps.m3u.models': mock_module}):
+            result = _make_plugin()._get_custom_m3u_account()
+        self.assertEqual(result, mock_account)
+        mock_module.M3UAccount.objects.get_or_create.assert_called_once_with(
+            name='custom',
+            defaults={'is_active': True, 'locked': True, 'max_streams': 0},
+        )
+
+
+# ── Webhook helpers ─────────────────────────────────────────────────────────
+
+class TestParseWebhookHeaders(unittest.TestCase):
+
+    def test_valid_json_object_parsed(self):
+        headers = _make_plugin()._parse_webhook_headers('{"Authorization": "Bearer tok", "X-Foo": "bar"}')
+        self.assertEqual(headers, {"Authorization": "Bearer tok", "X-Foo": "bar"})
+
+    def test_invalid_json_returns_empty_dict(self):
+        headers = _make_plugin()._parse_webhook_headers("not-valid-json{{{")
+        self.assertEqual(headers, {})
+
+    def test_json_array_returns_empty_dict(self):
+        headers = _make_plugin()._parse_webhook_headers('["a", "b"]')
+        self.assertEqual(headers, {})
+
+    def test_empty_string_returns_empty_dict(self):
+        self.assertEqual(_make_plugin()._parse_webhook_headers(""), {})
+
+    def test_none_returns_empty_dict(self):
+        self.assertEqual(_make_plugin()._parse_webhook_headers(None), {})
+
+    def test_whitespace_only_returns_empty_dict(self):
+        self.assertEqual(_make_plugin()._parse_webhook_headers("   "), {})
+
+
+class TestGetMediaRefreshWebhookConfig(unittest.TestCase):
+
+    def test_legacy_webhook_url_resolves_as_media_refresh(self):
+        config = _make_plugin()._get_media_refresh_webhook_config({"webhook_url": "http://jellyfin/refresh"})
+        self.assertEqual(config["url"], "http://jellyfin/refresh")
+        self.assertTrue(config["is_legacy"])
+
+    def test_new_media_refresh_url_takes_precedence_over_legacy(self):
+        settings = {
+            "webhook_url": "http://jellyfin/refresh",
+            "media_refresh_webhook_url": "http://new/refresh",
+        }
+        config = _make_plugin()._get_media_refresh_webhook_config(settings)
+        self.assertEqual(config["url"], "http://new/refresh")
+        self.assertFalse(config["is_legacy"])
+
+    def test_new_url_only_not_legacy(self):
+        config = _make_plugin()._get_media_refresh_webhook_config({"media_refresh_webhook_url": "http://n8n/refresh"})
+        self.assertFalse(config["is_legacy"])
+
+    def test_empty_settings_returns_empty_url(self):
+        config = _make_plugin()._get_media_refresh_webhook_config({})
+        self.assertEqual(config["url"], "")
+
+    def test_delay_falls_back_to_legacy_webhook_delay_seconds(self):
+        config = _make_plugin()._get_media_refresh_webhook_config({"webhook_delay_seconds": 10})
+        self.assertEqual(config["delay"], 10)
+
+    def test_new_delay_takes_precedence_over_legacy(self):
+        config = _make_plugin()._get_media_refresh_webhook_config({
+            "webhook_delay_seconds": 10,
+            "media_refresh_webhook_delay_seconds": 3,
+        })
+        self.assertEqual(config["delay"], 3)
+
+    def test_delay_defaults_to_5(self):
+        config = _make_plugin()._get_media_refresh_webhook_config({})
+        self.assertEqual(config["delay"], 5)
+
+    def test_delay_clamped_to_zero(self):
+        config = _make_plugin()._get_media_refresh_webhook_config({"webhook_delay_seconds": -5})
+        self.assertEqual(config["delay"], 0)
+
+    def test_delay_clamped_to_sixty(self):
+        config = _make_plugin()._get_media_refresh_webhook_config({"webhook_delay_seconds": 999})
+        self.assertEqual(config["delay"], 60)
+
+    def test_invalid_delay_defaults_to_five(self):
+        config = _make_plugin()._get_media_refresh_webhook_config({"webhook_delay_seconds": "oops"})
+        self.assertEqual(config["delay"], 5)
+
+    def test_method_defaults_to_post(self):
+        config = _make_plugin()._get_media_refresh_webhook_config({})
+        self.assertEqual(config["method"], "POST")
+
+    def test_custom_method_respected(self):
+        config = _make_plugin()._get_media_refresh_webhook_config({"media_refresh_webhook_method": "GET"})
+        self.assertEqual(config["method"], "GET")
+
+    def test_headers_parsed_from_json(self):
+        config = _make_plugin()._get_media_refresh_webhook_config({
+            "media_refresh_webhook_headers": '{"X-Token": "abc"}'
+        })
+        self.assertEqual(config["headers"], {"X-Token": "abc"})
+
+    def test_invalid_headers_ignored(self):
+        config = _make_plugin()._get_media_refresh_webhook_config({
+            "media_refresh_webhook_headers": "bad json"
+        })
+        self.assertEqual(config["headers"], {})
+
+
+class TestGetNotificationWebhookConfig(unittest.TestCase):
+
+    def test_legacy_telegram_url_resolves_as_notification(self):
+        config = _make_plugin()._get_notification_webhook_config({"telegram_webhook_url": "http://t.me/hook"})
+        self.assertEqual(config["url"], "http://t.me/hook")
+        self.assertTrue(config["is_legacy"])
+
+    def test_new_notification_url_takes_precedence_over_legacy(self):
+        settings = {
+            "telegram_webhook_url": "http://t.me/hook",
+            "notification_webhook_url": "http://n8n/hook",
+        }
+        config = _make_plugin()._get_notification_webhook_config(settings)
+        self.assertEqual(config["url"], "http://n8n/hook")
+        self.assertFalse(config["is_legacy"])
+
+    def test_new_url_only_not_legacy(self):
+        config = _make_plugin()._get_notification_webhook_config({"notification_webhook_url": "http://hook/"})
+        self.assertFalse(config["is_legacy"])
+
+    def test_dispatcharr_base_url_aliases_to_base_url(self):
+        config = _make_plugin()._get_notification_webhook_config({"dispatcharr_base_url": "http://tv.example.com"})
+        self.assertEqual(config["base_url"], "http://tv.example.com")
+
+    def test_notification_base_url_takes_precedence_over_dispatcharr_base_url(self):
+        settings = {
+            "dispatcharr_base_url": "http://old.example.com",
+            "notification_base_url": "http://new.example.com",
+        }
+        config = _make_plugin()._get_notification_webhook_config(settings)
+        self.assertEqual(config["base_url"], "http://new.example.com")
+
+    def test_base_url_trailing_slash_stripped(self):
+        config = _make_plugin()._get_notification_webhook_config({"dispatcharr_base_url": "http://tv.example.com/"})
+        self.assertEqual(config["base_url"], "http://tv.example.com")
+
+    def test_method_defaults_to_post(self):
+        config = _make_plugin()._get_notification_webhook_config({})
+        self.assertEqual(config["method"], "POST")
+
+    def test_invalid_headers_ignored_safely(self):
+        config = _make_plugin()._get_notification_webhook_config({
+            "notification_webhook_headers": "{invalid"
+        })
+        self.assertEqual(config["headers"], {})
+
+
+class TestWebhookAsyncAndNonBlocking(unittest.TestCase):
+
+    def test_trigger_webhook_returns_immediately_without_sleeping(self):
+        """_trigger_webhook must not call time.sleep in the caller's thread."""
+        p = _make_plugin()
+        p._generate_xmltv_cache = MagicMock()
+        threads_created = []
+
+        with patch("plugin.threading.Thread") as mock_thread_cls:
+            mock_t = MagicMock()
+            mock_thread_cls.return_value = mock_t
+            settings = {"webhook_url": "http://jellyfin/refresh", "webhook_delay_seconds": 30}
+            p._trigger_webhook(settings)
+
+        mock_thread_cls.assert_called_once()
+        mock_t.start.assert_called_once()
+
+    def test_trigger_webhook_thread_is_daemon(self):
+        p = _make_plugin()
+        p._generate_xmltv_cache = MagicMock()
+
+        with patch("plugin.threading.Thread") as mock_thread_cls:
+            mock_t = MagicMock()
+            mock_thread_cls.return_value = mock_t
+            p._trigger_webhook({"webhook_url": "http://example.com/"})
+
+        _, kwargs = mock_thread_cls.call_args
+        self.assertTrue(kwargs.get("daemon", False))
+
+    def test_failed_webhook_worker_does_not_propagate(self):
+        """Worker catches HTTP errors and does not raise."""
+        p = _make_plugin()
+        p._generate_xmltv_cache = MagicMock()
+
+        captured_target = {}
+
+        def fake_thread(**kwargs):
+            captured_target["fn"] = kwargs.get("target")
+            t = MagicMock()
+            t.start = MagicMock()
+            return t
+
+        with patch("plugin.threading.Thread", side_effect=fake_thread):
+            p._trigger_webhook({"webhook_url": "http://example.com/fail"})
+
+        with patch("urllib.request.urlopen", side_effect=OSError("refused")):
+            try:
+                captured_target["fn"]()
+            except Exception:
+                self.fail("Worker propagated exception on HTTP failure")
+
+    def test_trigger_webhook_no_url_returns_without_thread(self):
+        p = _make_plugin()
+        p._generate_xmltv_cache = MagicMock()
+
+        with patch("plugin.threading.Thread") as mock_thread_cls:
+            p._trigger_webhook({})
+
+        mock_thread_cls.assert_not_called()
+
+    def test_send_webhook_async_fires_thread_and_does_not_block(self):
+        p = _make_plugin()
+        with patch("plugin.threading.Thread") as mock_thread_cls:
+            mock_t = MagicMock()
+            mock_thread_cls.return_value = mock_t
+            p._send_webhook_async("test", "http://example.com/", "POST", {}, '{"x":1}', delay_seconds=0)
+        mock_thread_cls.assert_called_once()
+        mock_t.start.assert_called_once()
+
+
+class TestNotificationPayloads(unittest.TestCase):
+
+    def _capture_notification(self, settings, metadata=None, video_id="vid1",
+                               channel_number=90.1, channel_uuid="uuid-abc"):
+        p = _make_plugin()
+        captured = {}
+
+        def fake_send_async(kind, url, method, headers, body, delay_seconds=0):
+            captured["body"] = body
+
+        p._send_webhook_async = fake_send_async
+        meta = metadata or {"title": "NASA Live", "youtube_channel_name": "NASA", "thumbnail": "http://t.jpg"}
+        p._send_telegram_notification(settings, video_id, meta, channel_number, channel_uuid)
+        return captured.get("body")
+
+    def test_legacy_telegram_payload_has_exact_keys(self):
+        body = self._capture_notification({
+            "telegram_webhook_url": "http://t.me/hook",
+            "dispatcharr_base_url": "http://tv.example.com",
+        })
+        self.assertIsNotNone(body)
+        payload = json.loads(body)
+        self.assertEqual(set(payload.keys()), {"title", "channel", "url", "description", "timestamp"})
+
+    def test_legacy_telegram_payload_values(self):
+        body = self._capture_notification({
+            "telegram_webhook_url": "http://t.me/hook",
+            "dispatcharr_base_url": "http://tv.example.com",
+        }, channel_number=90.1, channel_uuid="uuid-abc")
+        payload = json.loads(body)
+        self.assertEqual(payload["title"], "NASA Live")
+        self.assertEqual(payload["channel"], "NASA")
+        self.assertIn("uuid-abc", payload["url"])
+        self.assertIn("90.1", payload["description"])
+
+    def test_legacy_telegram_skipped_when_no_base_url(self):
+        body = self._capture_notification({"telegram_webhook_url": "http://t.me/hook"})
+        self.assertIsNone(body)
+
+    def test_new_notification_payload_has_generic_keys(self):
+        body = self._capture_notification({
+            "notification_webhook_url": "http://n8n/hook",
+            "dispatcharr_base_url": "http://tv.example.com",
+        }, video_id="vid1", channel_number=90.1, channel_uuid="uuid-abc")
+        self.assertIsNotNone(body)
+        payload = json.loads(body)
+        expected_keys = {
+            "event", "plugin", "video_id", "title", "channel_name",
+            "channel_number", "dispatcharr_channel_uuid", "url", "thumbnail", "timestamp",
+        }
+        self.assertEqual(set(payload.keys()), expected_keys)
+
+    def test_new_notification_payload_values(self):
+        body = self._capture_notification({
+            "notification_webhook_url": "http://n8n/hook",
+            "dispatcharr_base_url": "http://tv.example.com",
+        }, video_id="vid42", channel_number=90.3, channel_uuid="uuid-xyz")
+        payload = json.loads(body)
+        self.assertEqual(payload["event"], "stream_added")
+        self.assertEqual(payload["plugin"], "youtubearr")
+        self.assertEqual(payload["video_id"], "vid42")
+        self.assertEqual(payload["channel_number"], "90.3")
+        self.assertEqual(payload["dispatcharr_channel_uuid"], "uuid-xyz")
+        self.assertIn("uuid-xyz", payload["url"])
+
+    def test_new_notification_url_without_base_url_still_sends(self):
+        """Generic payload works even with no base URL; url field is empty string."""
+        body = self._capture_notification({"notification_webhook_url": "http://n8n/hook"})
+        self.assertIsNotNone(body)
+        payload = json.loads(body)
+        self.assertEqual(payload["url"], "")
+
+    def test_no_url_configured_sends_nothing(self):
+        body = self._capture_notification({})
+        self.assertIsNone(body)
+
+    def test_new_notification_takes_precedence_over_legacy(self):
+        """When both telegram and notification_webhook_url are set, use generic payload."""
+        body = self._capture_notification({
+            "telegram_webhook_url": "http://t.me/hook",
+            "notification_webhook_url": "http://n8n/hook",
+            "dispatcharr_base_url": "http://tv.example.com",
+        })
+        payload = json.loads(body)
+        self.assertIn("event", payload)
+        self.assertNotIn("description", payload)
+
+
+class TestDiagnostics(unittest.TestCase):
+
+    def _make_diag_plugin(self, ytdlp=True, qjs=False):
+        p = _make_plugin(qjs=qjs)
+        if not ytdlp:
+            p._ytdlp_path = None
+        p._plugin_key = "youtubearr"
+        p._monitor_thread = None
+        p._monitoring_active = False
+        # Prevent log file reads in tests
+        p._log_path = MagicMock()
+        p._log_path.exists.return_value = False
+        # _base_dir is only used for cookies.txt path check
+        p._base_dir = MagicMock()
+        # Stub subprocess-calling helpers to avoid real invocations
+        p._get_ytdlp_version = MagicMock(
+            return_value="2025.01.01" if ytdlp else "unavailable: yt-dlp not found"
+        )
+        p._get_qjs_version = MagicMock(
+            return_value="QuickJS-ng version 0.14.0" if qjs else "not configured"
+        )
+        return p
+
+    # Routing
+
+    def test_run_routes_to_diagnostics(self):
+        p = self._make_diag_plugin()
+        p._handle_diagnostics = MagicMock(return_value={"status": "success", "message": "ok", "details": {}})
+        result = p.run("diagnostics", {}, {"settings": {}})
+        p._handle_diagnostics.assert_called_once()
+        self.assertEqual(result["status"], "success")
+
+    # Core behaviour with empty settings
+
+    def test_diagnostics_returns_details_dict_no_traceback(self):
+        p = self._make_diag_plugin()
+        result = p._handle_diagnostics({"settings": {}})
+        self.assertIn("details", result)
+        self.assertIsInstance(result["details"], dict)
+        self.assertIn("status", result)
+        self.assertIn("message", result)
+
+    def test_diagnostics_includes_required_fields(self):
+        p = self._make_diag_plugin()
+        result = p._handle_diagnostics({"settings": {}})
+        d = result["details"]
+        for field in ("plugin_version", "plugin_key", "monitoring_active", "monitor_thread_alive",
+                      "last_poll_time", "tracked_stream_count", "extraction_failure_count",
+                      "ytdlp_path", "ytdlp_version", "qjs_path", "qjs_version",
+                      "cookies_configured", "cookies_file_present",
+                      "media_refresh_webhook_configured", "notification_webhook_configured"):
+            self.assertIn(field, d, f"missing field: {field}")
+
+    # yt-dlp missing → error status
+
+    def test_missing_ytdlp_yields_error_status(self):
+        p = self._make_diag_plugin(ytdlp=False)
+        result = p._handle_diagnostics({"settings": {}})
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["details"]["ytdlp_path"], "not found")
+
+    def test_missing_ytdlp_does_not_raise(self):
+        p = self._make_diag_plugin(ytdlp=False)
+        try:
+            result = p._handle_diagnostics({"settings": {}})
+        except Exception as exc:
+            self.fail(f"_handle_diagnostics raised {exc!r} on missing yt-dlp")
+
+    # _get_ytdlp_version helpers
+
+    def test_get_ytdlp_version_parses_stdout(self):
+        p = _make_plugin()
+        with patch("subprocess.run", return_value=MagicMock(stdout="2025.01.01\n", stderr="", returncode=0)):
+            self.assertEqual(p._get_ytdlp_version(), "2025.01.01")
+
+    def test_get_ytdlp_version_handles_timeout(self):
+        p = _make_plugin()
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="yt-dlp", timeout=5)):
+            ver = p._get_ytdlp_version()
+        self.assertIn("timeout", ver.lower())
+
+    def test_get_ytdlp_version_handles_missing_binary(self):
+        p = _make_plugin()
+        with patch("subprocess.run", side_effect=FileNotFoundError("no such file")):
+            ver = p._get_ytdlp_version()
+        self.assertIn("unavailable", ver.lower())
+
+    def test_get_ytdlp_version_handles_no_path(self):
+        p = _make_plugin()
+        p._ytdlp_path = None
+        ver = p._get_ytdlp_version()
+        self.assertIn("unavailable", ver.lower())
+
+    # _get_qjs_version helpers
+
+    def test_get_qjs_version_parses_nonzero_exit(self):
+        """qjs --version may exit nonzero; version must still be parsed from stderr."""
+        p = _make_plugin(qjs=True)
+        mock_result = MagicMock(stdout="", stderr="QuickJS-ng version 0.14.0\n", returncode=1)
+        with patch("subprocess.run", return_value=mock_result):
+            ver = p._get_qjs_version()
+        self.assertIn("QuickJS-ng version 0.14.0", ver)
+
+    def test_get_qjs_version_parses_stdout(self):
+        p = _make_plugin(qjs=True)
+        mock_result = MagicMock(stdout="QuickJS-ng version 0.14.0\n", stderr="", returncode=0)
+        with patch("subprocess.run", return_value=mock_result):
+            ver = p._get_qjs_version()
+        self.assertIn("QuickJS-ng version 0.14.0", ver)
+
+    def test_get_qjs_version_no_path_returns_not_configured(self):
+        p = _make_plugin(qjs=False)
+        self.assertEqual(p._get_qjs_version(), "not configured")
+
+    def test_get_qjs_version_handles_timeout(self):
+        p = _make_plugin(qjs=True)
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="qjs", timeout=5)):
+            ver = p._get_qjs_version()
+        self.assertIn("timeout", ver.lower())
+
+    # Extraction failure timestamps
+
+    def test_extraction_failure_oldest_newest(self):
+        import time as time_mod
+        p = self._make_diag_plugin()
+        now = time_mod.time()
+        p._extraction_failures = {"v1": now - 100.0, "v2": now - 200.0, "v3": now - 50.0}
+        result = p._handle_diagnostics({"settings": {}})
+        d = result["details"]
+        self.assertEqual(d["extraction_failure_count"], 3)
+        self.assertIn("extraction_failure_oldest", d)
+        self.assertIn("extraction_failure_newest", d)
+        self.assertLess(d["extraction_failure_oldest"], d["extraction_failure_newest"])
+
+    def test_extraction_failure_zero_no_timestamps(self):
+        p = self._make_diag_plugin()
+        p._extraction_failures = {}
+        result = p._handle_diagnostics({"settings": {}})
+        d = result["details"]
+        self.assertEqual(d["extraction_failure_count"], 0)
+        self.assertNotIn("extraction_failure_oldest", d)
+
+    # Webhook configured flags
+
+    def test_webhook_flags_new_generic_settings(self):
+        p = self._make_diag_plugin()
+        ctx = {"settings": {
+            "media_refresh_webhook_url": "http://hook/refresh",
+            "notification_webhook_url": "http://hook/notify",
+        }}
+        d = p._handle_diagnostics(ctx)["details"]
+        self.assertTrue(d["media_refresh_webhook_configured"])
+        self.assertFalse(d["media_refresh_webhook_is_legacy"])
+        self.assertTrue(d["notification_webhook_configured"])
+        self.assertFalse(d["notification_webhook_is_legacy"])
+
+    def test_webhook_flags_legacy_settings(self):
+        p = self._make_diag_plugin()
+        ctx = {"settings": {
+            "webhook_url": "http://legacy/refresh",
+            "telegram_webhook_url": "http://legacy/notify",
+        }}
+        d = p._handle_diagnostics(ctx)["details"]
+        self.assertTrue(d["media_refresh_webhook_configured"])
+        self.assertTrue(d["media_refresh_webhook_is_legacy"])
+        self.assertTrue(d["notification_webhook_configured"])
+        self.assertTrue(d["notification_webhook_is_legacy"])
+
+    def test_webhook_not_configured(self):
+        p = self._make_diag_plugin()
+        d = p._handle_diagnostics({"settings": {}})["details"]
+        self.assertFalse(d["media_refresh_webhook_configured"])
+        self.assertFalse(d["notification_webhook_configured"])
+
+    # DB count failures captured as unavailable
+
+    def test_db_count_failure_returns_unavailable_string(self):
+        p = _make_plugin()
+        with patch("plugin.Stream") as mock_stream:
+            mock_stream.objects.filter.side_effect = Exception("DB down")
+            count = p._count_owned_streams()
+        self.assertIsInstance(count, str)
+        self.assertIn("unavailable", count)
+
+    def test_db_channel_count_failure_returns_unavailable_string(self):
+        p = _make_plugin()
+        with patch("plugin.Channel") as mock_chan:
+            mock_chan.objects.filter.side_effect = Exception("DB down")
+            count = p._count_owned_channels()
+        self.assertIsInstance(count, str)
+        self.assertIn("unavailable", count)
+
+    def test_db_program_count_failure_returns_unavailable_string(self):
+        p = _make_plugin()
+        with patch("plugin.ProgramData") as mock_pd:
+            mock_pd.objects.filter.side_effect = Exception("DB down")
+            count = p._count_owned_programs()
+        self.assertIsInstance(count, str)
+        self.assertIn("unavailable", count)
+
+    # cookies_content never exposed
+
+    def test_diagnostics_does_not_expose_cookies_content(self):
+        p = self._make_diag_plugin()
+        secret = "secret-cookie-value-xyz-unique"
+        ctx = {"settings": {"cookies_content": f"# Netscape HTTP Cookie File\n.example.com\t{secret}"}}
+        result = p._handle_diagnostics(ctx)
+        details_str = json.dumps(result["details"], default=str)
+        self.assertNotIn(secret, details_str)
+        self.assertNotIn("cookies_content", details_str)
+        # But should flag that cookies are configured
+        self.assertTrue(result["details"]["cookies_configured"])
+
+    def test_diagnostics_cookies_not_configured_when_empty(self):
+        p = self._make_diag_plugin()
+        result = p._handle_diagnostics({"settings": {"cookies_content": ""}})
+        self.assertFalse(result["details"]["cookies_configured"])
+
+
+class TestGetEpgCounts(unittest.TestCase):
+
+    def test_epg_source_found_returns_numeric_counts(self):
+        p = _make_plugin()
+        mock_source = MagicMock()
+        with patch("plugin.EPGSource") as mock_es, \
+             patch("plugin.EPGData") as mock_ed, \
+             patch("plugin.ProgramData") as mock_pd:
+            mock_es.objects.filter.return_value.first.return_value = mock_source
+            mock_ed.objects.filter.return_value.count.return_value = 3
+            mock_pd.objects.filter.return_value.count.return_value = 12
+            result = p._get_epg_counts({"epg_source_name": "YouTube Live"})
+        self.assertEqual(result["epg_source"], "YouTube Live")
+        self.assertEqual(result["epg_data_count"], 3)
+        self.assertEqual(result["program_count"], 12)
+
+    def test_epg_source_not_found_returns_zeroes(self):
+        p = _make_plugin()
+        with patch("plugin.EPGSource") as mock_es:
+            mock_es.objects.filter.return_value.first.return_value = None
+            result = p._get_epg_counts({"epg_source_name": "YouTube Live"})
+        self.assertIn("not found", result["epg_source"])
+        self.assertEqual(result["epg_data_count"], 0)
+        self.assertEqual(result["program_count"], 0)
+
+    def test_query_failure_all_fields_use_consistent_unavailable(self):
+        p = _make_plugin()
+        with patch("plugin.EPGSource") as mock_es:
+            mock_es.objects.filter.side_effect = RuntimeError("DB down")
+            result = p._get_epg_counts({})
+        for key in ("epg_source", "epg_data_count", "program_count"):
+            self.assertEqual(
+                result[key],
+                "unavailable: RuntimeError",
+                f"{key!r} should be 'unavailable: RuntimeError', got {result[key]!r}",
+            )
+
+
+class TestGetRecentLogSummary(unittest.TestCase):
+
+    def test_missing_log_file_returns_defaults(self):
+        p = _make_plugin()
+        p._log_path = Path("/nonexistent/path/youtubearr.log")
+        result = p._get_recent_log_summary()
+        self.assertEqual(result["error_count"], 0)
+        self.assertEqual(result["recent_errors"], [])
+        self.assertEqual(result["status"], "log file not found")
+
+    def test_log_with_no_errors_returns_zero_count(self):
+        p = _make_plugin()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False) as f:
+            f.write("INFO: all good\nINFO: still fine\n")
+            tmp_path = Path(f.name)
+        try:
+            p._log_path = tmp_path
+            result = p._get_recent_log_summary()
+            self.assertEqual(result["error_count"], 0)
+            self.assertEqual(result["recent_errors"], [])
+            self.assertEqual(result["status"], "ok")
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    def test_log_with_errors_returns_correct_count(self):
+        p = _make_plugin()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False) as f:
+            f.write("INFO: ok\nERROR: something broke\nINFO: ok\n"
+                    "ERROR: another problem\nERROR: third issue\n")
+            tmp_path = Path(f.name)
+        try:
+            p._log_path = tmp_path
+            result = p._get_recent_log_summary()
+            self.assertEqual(result["error_count"], 3)
+            self.assertEqual(len(result["recent_errors"]), 3)
+            self.assertEqual(result["status"], "ok")
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    def test_large_log_recent_errors_capped_at_five(self):
+        p = _make_plugin()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False) as f:
+            for i in range(20):
+                f.write(f"ERROR: error number {i}\n")
+            tmp_path = Path(f.name)
+        try:
+            p._log_path = tmp_path
+            result = p._get_recent_log_summary()
+            self.assertEqual(result["error_count"], 20)
+            self.assertLessEqual(len(result["recent_errors"]), 5)
+            self.assertEqual(result["status"], "ok")
+        finally:
+            tmp_path.unlink(missing_ok=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Prepares YouTubearr v1.20.0 with operational polish, compatibility improvements, and a stale-stream watchdog fix.

### Added

- Diagnostics action for non-destructive plugin health checks
- Generic media refresh webhook support
- Generic notification webhook support
- Generic webhook fields in plugin UI
- Ownership metadata on created streams/program data
- Dispatcharr custom M3U account association
- Expanded test coverage

### Fixed

- Removed broken Celery beat health-check registration that referenced nonexistent `core.tasks.check_plugin_health`
- Added cleanup for existing legacy `youtubearr_youtubearr_health_check` scheduled task entries
- Preserved monitor-thread self-healing through plugin-owned heartbeat/status checks instead of nonexistent Dispatcharr core tasks
- Added diagnostics for stale tracked stream URLs and legacy Celery task presence
- Custom M3U fallback now matches Dispatcharr pattern
- Decimal display suffix parsing for `.11`, `.21`, etc.
- Stale extraction failure cache pruning
- Webhook delays no longer block monitor/manual refresh caller threads

### Compatibility

- Legacy `webhook_url`, `webhook_delay_seconds`, `telegram_webhook_url`, and `dispatcharr_base_url` remain supported as aliases
- `min_dispatcharr_version` remains `v0.20.0`

## Validation

- Unit tests: 156 passed
- Integration tests: 7 passed against live YouTube
- `python3 -m py_compile plugin.py`
- `git diff --check`
- Secret/unsafe pattern scan reviewed


Fixes #22
